### PR TITLE
Added Semifluid Generator

### DIFF
--- a/src/main/java/techreborn/blocks/generator/BlockSemiFluidGenerator.java
+++ b/src/main/java/techreborn/blocks/generator/BlockSemiFluidGenerator.java
@@ -1,9 +1,19 @@
 package techreborn.blocks.generator;
 
+import java.util.Map;
+import net.minecraftforge.fluids.*;
+import net.minecraft.util.ChatComponentText;
+
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
+import net.minecraft.world.World;
+import techreborn.Core;
 import techreborn.blocks.BlockMachineBase;
+import techreborn.client.GuiHandler;
+import techreborn.tiles.TileSemifluidGenerator;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -22,6 +32,22 @@ public class BlockSemiFluidGenerator extends BlockMachineBase {
 	{
 		super(material);
 		setBlockName("techreborn.semifluidgenerator");
+	}
+	
+	@Override
+	public TileEntity createNewTileEntity(World world, int p_149915_2_)
+	{
+		return new TileSemifluidGenerator();
+	}
+	
+	@Override
+	public boolean onBlockActivated(World world, int x, int y, int z,
+			EntityPlayer player, int side, float hitX, float hitY, float hitZ)
+	{
+		if (!player.isSneaking())
+			player.openGui(Core.INSTANCE, GuiHandler.semifluidGeneratorID, world, x, y,
+					z);
+		return true;
 	}
 
 	@Override

--- a/src/main/java/techreborn/client/GuiHandler.java
+++ b/src/main/java/techreborn/client/GuiHandler.java
@@ -23,6 +23,7 @@ import techreborn.client.container.ContainerQuantumChest;
 import techreborn.client.container.ContainerQuantumTank;
 import techreborn.client.container.ContainerRollingMachine;
 import techreborn.client.container.ContainerThermalGenerator;
+import techreborn.client.container.ContainerSemifluidGenerator;
 import techreborn.client.gui.GuiAesu;
 import techreborn.client.gui.GuiAlloyFurnace;
 import techreborn.client.gui.GuiAlloySmelter;
@@ -43,6 +44,7 @@ import techreborn.client.gui.GuiQuantumChest;
 import techreborn.client.gui.GuiQuantumTank;
 import techreborn.client.gui.GuiRollingMachine;
 import techreborn.client.gui.GuiThermalGenerator;
+import techreborn.client.gui.GuiSemifluidGenerator;
 import techreborn.pda.GuiPda;
 import techreborn.tiles.*;
 import cpw.mods.fml.common.network.IGuiHandler;
@@ -70,6 +72,7 @@ public class GuiHandler implements IGuiHandler {
 	public static final int alloyFurnaceID = 18;
 	public static final int sawMillID = 19;
 	public static final int chemicalReactorID = 20;
+	public static final int semifluidGeneratorID = 21;
 
 
 
@@ -81,6 +84,10 @@ public class GuiHandler implements IGuiHandler {
 		{
 			return new ContainerThermalGenerator(
 					(TileThermalGenerator) world.getTileEntity(x, y, z), player);
+		} else if (ID == semifluidGeneratorID)
+		{
+			return new ContainerSemifluidGenerator(
+				(TileSemifluidGenerator) world.getTileEntity(x, y, z), player);			
 		} else if (ID == quantumTankID)
 		{
 			return new ContainerQuantumTank(
@@ -173,7 +180,12 @@ public class GuiHandler implements IGuiHandler {
 		{
 			return new GuiThermalGenerator(player,
 					(TileThermalGenerator) world.getTileEntity(x, y, z));
-		} else if (ID == quantumTankID)
+		} else if (ID == semifluidGeneratorID)
+		{
+			return new GuiSemifluidGenerator(player,
+				(TileSemifluidGenerator) world.getTileEntity(x, y, z));			
+		}
+		else if (ID == quantumTankID)
 		{
 			return new GuiQuantumTank(player,
 					(TileQuantumTank) world.getTileEntity(x, y, z));

--- a/src/main/java/techreborn/client/container/ContainerSemifluidGenerator.java
+++ b/src/main/java/techreborn/client/container/ContainerSemifluidGenerator.java
@@ -1,0 +1,50 @@
+package techreborn.client.container;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Slot;
+import techreborn.client.SlotFake;
+import techreborn.client.SlotOutput;
+import techreborn.tiles.TileSemifluidGenerator;
+
+public class ContainerSemifluidGenerator extends TechRebornContainer {
+	public TileSemifluidGenerator tileSemifluidGenerator;
+	public EntityPlayer player;
+
+	public ContainerSemifluidGenerator(TileSemifluidGenerator tileSemifluidGenerator,
+			EntityPlayer player)
+	{
+		super();
+		this.tileSemifluidGenerator = tileSemifluidGenerator;
+		this.player = player;
+
+		this.addSlotToContainer(new Slot(tileSemifluidGenerator.inventory, 0, 80,
+				17));
+		this.addSlotToContainer(new SlotOutput(tileSemifluidGenerator.inventory,
+				1, 80, 53));
+		this.addSlotToContainer(new SlotFake(tileSemifluidGenerator.inventory, 2,
+				59, 42, false, false, 1));
+
+		int i;
+
+		for (i = 0; i < 3; ++i)
+		{
+			for (int j = 0; j < 9; ++j)
+			{
+				this.addSlotToContainer(new Slot(player.inventory, j + i * 9
+						+ 9, 8 + j * 18, 84 + i * 18));
+			}
+		}
+
+		for (i = 0; i < 9; ++i)
+		{
+			this.addSlotToContainer(new Slot(player.inventory, i, 8 + i * 18,
+					142));
+		}
+	}
+
+	@Override
+	public boolean canInteractWith(EntityPlayer player)
+	{
+		return true;
+	}
+}

--- a/src/main/java/techreborn/client/gui/GuiSemifluidGenerator.java
+++ b/src/main/java/techreborn/client/gui/GuiSemifluidGenerator.java
@@ -1,0 +1,49 @@
+package techreborn.client.gui;
+
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.StatCollector;
+import techreborn.client.container.ContainerSemifluidGenerator;
+import techreborn.tiles.TileSemifluidGenerator;
+
+public class GuiSemifluidGenerator extends GuiContainer {
+
+	//TODO: use semifluid generator texture
+	private static final ResourceLocation texture = new ResourceLocation(
+			"techreborn", "textures/gui/ThermalGenerator.png");
+
+	TileSemifluidGenerator tile;
+
+	public GuiSemifluidGenerator(EntityPlayer player, TileSemifluidGenerator tile)
+	{
+		super(new ContainerSemifluidGenerator(tile, player));
+		this.xSize = 176;
+		this.ySize = 167;
+		this.tile = tile;
+	}
+
+	@Override
+	protected void drawGuiContainerBackgroundLayer(float p_146976_1_,
+			int p_146976_2_, int p_146976_3_)
+	{
+		this.mc.getTextureManager().bindTexture(texture);
+		int k = (this.width - this.xSize) / 2;
+		int l = (this.height - this.ySize) / 2;
+		this.drawTexturedModalRect(k, l, 0, 0, this.xSize, this.ySize);
+	}
+
+	protected void drawGuiContainerForegroundLayer(int p_146979_1_,
+			int p_146979_2_)
+	{
+		String name = "Semifluid Generator";
+		this.fontRendererObj.drawString(name, this.xSize / 2 - this.fontRendererObj.getStringWidth(name) / 2, 6, 4210752);
+		this.fontRendererObj.drawString(
+				I18n.format("container.inventory", new Object[0]), 8,
+				this.ySize - 96 + 2, 4210752);
+		this.fontRendererObj.drawString("Liquid Amount", 10, 20, 16448255);
+		this.fontRendererObj.drawString(tile.tank.getFluidAmount() + "", 10,
+				30, 16448255);
+	}
+}

--- a/src/main/java/techreborn/init/ModBlocks.java
+++ b/src/main/java/techreborn/init/ModBlocks.java
@@ -59,6 +59,7 @@ import techreborn.tiles.TileQuantumChest;
 import techreborn.tiles.TileQuantumTank;
 import techreborn.tiles.TileRollingMachine;
 import techreborn.tiles.TileThermalGenerator;
+import techreborn.tiles.TileSemifluidGenerator;
 import techreborn.util.LogHelper;
 import cpw.mods.fml.common.registry.GameRegistry;
 
@@ -195,6 +196,7 @@ public class ModBlocks {
 		
 		Semifluidgenerator = new BlockSemiFluidGenerator(Material.rock);
 		GameRegistry.registerBlock(Semifluidgenerator, "semifluidgenerator");
+		GameRegistry.registerTileEntity(TileSemifluidGenerator.class, "TileSemifluidGenerator");
 		
 		AlloyFurnace = new BlockAlloyFurnace(Material.rock);
 		GameRegistry.registerBlock(AlloyFurnace, "alloyfurnace");

--- a/src/main/java/techreborn/tiles/TileSemifluidGenerator.java
+++ b/src/main/java/techreborn/tiles/TileSemifluidGenerator.java
@@ -1,0 +1,286 @@
+package techreborn.tiles;
+
+import java.util.Map;
+import java.util.HashMap;
+
+import ic2.api.energy.prefab.BasicSource;
+import ic2.api.energy.tile.IEnergyTile;
+import ic2.api.tile.IWrenchable;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.*;
+import techreborn.config.ConfigTechReborn;
+import techreborn.init.ModBlocks;
+import techreborn.util.FluidUtils;
+import techreborn.util.Inventory;
+import techreborn.util.Tank;
+
+public class TileSemifluidGenerator extends TileEntity implements IWrenchable,
+		IFluidHandler, IInventory, IEnergyTile {
+
+	public Tank tank = new Tank("TileSemifluidGenerator",
+			FluidContainerRegistry.BUCKET_VOLUME * 10, this);
+	public Inventory inventory = new Inventory(3, "TileSemifluidGenerator", 64);
+	public BasicSource energySource;
+	
+	//TODO: run this off config
+	public static final int euTick = 8;
+
+	Map<String, Integer> fluids = new HashMap<String, Integer>();
+	
+	//We use this to keep track of fractional millibuckets, allowing us to hit our eu/bucket targets while still only ever removing integer millibucket amounts.
+	double pendingWithdraw = 0.0;
+	
+	public TileSemifluidGenerator()
+	{
+		//TODO: fix this to have SemiFluid generator values
+		this.energySource = new BasicSource(this,
+				ConfigTechReborn.ThermalGeneratorCharge,
+				ConfigTechReborn.ThermalGeneratorTier);
+				
+		fluids.put("creosote", 3000);
+		fluids.put("biomass", 8000);
+		fluids.put("oil", 64000);
+		fluids.put("fluidsodium", 30000);
+		fluids.put("fluidlithium", 60000);
+	}
+
+	@Override
+	public boolean wrenchCanSetFacing(EntityPlayer entityPlayer, int side)
+	{
+		return false;
+	}
+
+	@Override
+	public short getFacing()
+	{
+		return 0;
+	}
+
+	@Override
+	public void setFacing(short facing)
+	{
+	}
+
+	@Override
+	public boolean wrenchCanRemove(EntityPlayer entityPlayer)
+	{
+		if (entityPlayer.isSneaking())
+		{
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public float getWrenchDropRate()
+	{
+		return 1.0F;
+	}
+
+	@Override
+	public ItemStack getWrenchDrop(EntityPlayer entityPlayer)
+	{
+		return new ItemStack(ModBlocks.Semifluidgenerator, 1);
+	}
+
+	@Override
+	public int fill(ForgeDirection from, FluidStack resource, boolean doFill)
+	{
+		return tank.fill(resource, doFill);
+	}
+
+	@Override
+	public FluidStack drain(ForgeDirection from, FluidStack resource,
+			boolean doDrain)
+	{
+		return tank.drain(resource.amount, doDrain);
+	}
+
+	@Override
+	public FluidStack drain(ForgeDirection from, int maxDrain, boolean doDrain)
+	{
+		return tank.drain(maxDrain, doDrain);
+	}
+
+	@Override
+	public boolean canFill(ForgeDirection from, Fluid fluid)
+	{		
+		if (fluid != null)
+		{
+			return fluids.containsKey(FluidRegistry.getFluidName(fluid));
+		}
+		return false;
+	}
+
+	@Override
+	public boolean canDrain(ForgeDirection from, Fluid fluid)
+	{
+		return tank.getFluid() == null || tank.getFluid().getFluid() == fluid;
+	}
+
+	@Override
+	public FluidTankInfo[] getTankInfo(ForgeDirection from)
+	{
+		return getTankInfo(from);
+	}
+
+	@Override
+	public void readFromNBT(NBTTagCompound tagCompound)
+	{
+		super.readFromNBT(tagCompound);
+		tank.readFromNBT(tagCompound);
+		inventory.readFromNBT(tagCompound);
+		energySource.readFromNBT(tagCompound);
+	}
+
+	@Override
+	public void writeToNBT(NBTTagCompound tagCompound)
+	{
+		super.writeToNBT(tagCompound);
+		tank.writeToNBT(tagCompound);
+		inventory.writeToNBT(tagCompound);
+		energySource.writeToNBT(tagCompound);
+	}
+
+	public Packet getDescriptionPacket()
+	{
+		NBTTagCompound nbtTag = new NBTTagCompound();
+		writeToNBT(nbtTag);
+		return new S35PacketUpdateTileEntity(this.xCoord, this.yCoord,
+				this.zCoord, 1, nbtTag);
+	}
+
+	@Override
+	public void onDataPacket(NetworkManager net,
+			S35PacketUpdateTileEntity packet)
+	{
+		worldObj.markBlockRangeForRenderUpdate(xCoord, yCoord, zCoord, xCoord,
+				yCoord, zCoord);
+		readFromNBT(packet.func_148857_g());
+	}
+
+	@Override
+	public void updateEntity()
+	{
+		super.updateEntity();
+		FluidUtils.drainContainers(this, inventory, 0, 1);
+		energySource.updateEntity();
+		if (tank.getFluidAmount() > 0
+				&& energySource.getCapacity() - energySource.getEnergyStored() >= euTick)
+		{
+			Integer euPerBucket = fluids.get(tank.getFluidType().getName());
+			//float totalTicks = (float)euPerBucket / 8f; //x eu per bucket / 8 eu per tick
+			//float millibucketsPerTick = 1000f / totalTicks;			
+			float millibucketsPerTick = 8000f / (float)euPerBucket;			
+			pendingWithdraw += millibucketsPerTick;
+			
+			int currentWithdraw = (int)pendingWithdraw; //float --> int conversion floors the float
+			pendingWithdraw -= currentWithdraw;
+			
+			tank.drain(currentWithdraw, true);
+			energySource.addEnergy(euTick);
+		}
+		if (tank.getFluidType() != null && getStackInSlot(2) == null)
+		{
+			inventory.setInventorySlotContents(2, new ItemStack(tank
+					.getFluidType().getBlock()));
+		} else if (tank.getFluidType() == null && getStackInSlot(2) != null)
+		{
+			setInventorySlotContents(2, null);
+		}
+	}
+
+	@Override
+	public int getSizeInventory()
+	{
+		return inventory.getSizeInventory();
+	}
+
+	@Override
+	public ItemStack getStackInSlot(int p_70301_1_)
+	{
+		return inventory.getStackInSlot(p_70301_1_);
+	}
+
+	@Override
+	public ItemStack decrStackSize(int p_70298_1_, int p_70298_2_)
+	{
+		return inventory.decrStackSize(p_70298_1_, p_70298_2_);
+	}
+
+	@Override
+	public ItemStack getStackInSlotOnClosing(int p_70304_1_)
+	{
+		return inventory.getStackInSlotOnClosing(p_70304_1_);
+	}
+
+	@Override
+	public void setInventorySlotContents(int p_70299_1_, ItemStack p_70299_2_)
+	{
+		inventory.setInventorySlotContents(p_70299_1_, p_70299_2_);
+	}
+
+	@Override
+	public String getInventoryName()
+	{
+		return inventory.getInventoryName();
+	}
+
+	@Override
+	public boolean hasCustomInventoryName()
+	{
+		return inventory.hasCustomInventoryName();
+	}
+
+	@Override
+	public int getInventoryStackLimit()
+	{
+		return inventory.getInventoryStackLimit();
+	}
+
+	@Override
+	public boolean isUseableByPlayer(EntityPlayer p_70300_1_)
+	{
+		return inventory.isUseableByPlayer(p_70300_1_);
+	}
+
+	@Override
+	public void openInventory()
+	{
+		inventory.openInventory();
+	}
+
+	@Override
+	public void closeInventory()
+	{
+		inventory.closeInventory();
+	}
+
+	@Override
+	public boolean isItemValidForSlot(int p_94041_1_, ItemStack p_94041_2_)
+	{
+		return inventory.isItemValidForSlot(p_94041_1_, p_94041_2_);
+	}
+
+	@Override
+	public void onChunkUnload()
+	{
+		energySource.onChunkUnload();
+	}
+
+	@Override
+	public void invalidate()
+	{
+		energySource.invalidate();
+		super.invalidate();
+	}
+
+}


### PR DESCRIPTION
Added functionality to the semifluid generator block. Currently supports creosote, biomass, oil, fluidsodium, and fluidlithium, with the EU numbers from http://ftbwiki.org/Semifluid_Generator_%28GregTech%29. Suffers from issue #19, I haven't been able to figure that out. Adding fluid manually when #19 is in effect results in more strange behavior, especially if you add a different supported fluid than the one that was already there, but hidden.
There are a number of config todos related to this machine.