### PR TITLE
Make treetap working with the IC2 rubber tree (Fix #786)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ dependencies {
 	deobfCompile "slimeknights:TConstruct:1.10.2-2.5.3.jenkins384"
 	deobfCompile "slimeknights.mantle:Mantle:1.10.2-1.0.0.jenkins170"
     deobfCompile "mcjty.theoneprobe:TheOneProbe:1.9.4-1.0.4-14"
-    deobfCompile 'net.industrial-craft:industrialcraft-2:2.6.58-ex110:dev'
+    deobfCompile 'net.industrial-craft:industrialcraft-2:2.6.129-ex110'
 }
 
 
@@ -175,7 +175,7 @@ uploadArchives {
             }
         }
         else
-        { 
+        {
 			//this is when the build is executed on the master node
 			println 'Uploading to local Maven Repo'
            repository(url: "file:///var/www/maven/")

--- a/src/main/java/techreborn/blocks/BlockRubberLog.java
+++ b/src/main/java/techreborn/blocks/BlockRubberLog.java
@@ -151,7 +151,7 @@ public class BlockRubberLog extends Block implements ITexturedBlock {
 		super.onBlockActivated(worldIn, pos, state, playerIn, hand, heldItem, side, hitX, hitY, hitZ);
 		ItemStack stack = playerIn.getHeldItem(EnumHand.MAIN_HAND);
 		if (stack != null)
-			if ((stack.getItem() instanceof ItemElectricTreetap && PoweredItem.canUseEnergy(20, stack)) || stack.getItem() instanceof ItemTreeTap)
+			if ((stack.getItem() instanceof ItemElectricTreetap && PoweredItem.canUseEnergy(20, stack)) || stack.getItem() instanceof ItemTreeTap) {
 				if (state.getValue(HAS_SAP)) {
 					if (state.getValue(SAP_SIDE) == side) {
 						worldIn.setBlockState(pos,
@@ -180,6 +180,7 @@ public class BlockRubberLog extends Block implements ITexturedBlock {
 						return true;
 					}
 				}
+			}
 		return false;
 	}
 

--- a/src/main/java/techreborn/items/tools/ItemElectricTreetap.java
+++ b/src/main/java/techreborn/items/tools/ItemElectricTreetap.java
@@ -1,17 +1,26 @@
 package techreborn.items.tools;
 
+import ic2.core.item.tool.ItemTreetap;
 import me.modmuss50.jsonDestroyer.api.ITexturedItem;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.RebornCore;
 import reborncore.api.power.IEnergyItemInfo;
 import reborncore.common.powerSystem.PoweredItem;
 import techreborn.client.TechRebornCreativeTab;
+import techreborn.compat.CompatManager;
 import techreborn.lib.ModInfo;
 
 import java.util.List;
@@ -26,11 +35,22 @@ public class ItemElectricTreetap extends Item implements IEnergyItemInfo, ITextu
 	public int cost = 20;
 
 	public ItemElectricTreetap() {
-		super();
 		setUnlocalizedName("techreborn.electric_treetap");
 		setCreativeTab(TechRebornCreativeTab.instance);
 		setMaxStackSize(1);
 		RebornCore.jsonDestroyer.registerObject(this);
+	}
+
+	@Override
+	public EnumActionResult onItemUse(ItemStack stack, EntityPlayer playerIn, World worldIn, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
+		IBlockState state = worldIn.getBlockState(pos);
+		Block block = state.getBlock();
+		if(CompatManager.isIC2Loaded && block == Block.getBlockFromName("ic2:rubber_wood") && PoweredItem.canUseEnergy(20, stack))
+			if (ItemTreetap.attemptExtract(playerIn, worldIn, pos, side, state, null) && !worldIn.isRemote) {
+				PoweredItem.useEnergy(20, stack);
+				return EnumActionResult.SUCCESS;
+			}
+		return EnumActionResult.PASS;
 	}
 
 	@Override

--- a/src/main/java/techreborn/items/tools/ItemTreeTap.java
+++ b/src/main/java/techreborn/items/tools/ItemTreeTap.java
@@ -1,14 +1,23 @@
 package techreborn.items.tools;
 
+import ic2.core.item.tool.ItemTreetap;
 import me.modmuss50.jsonDestroyer.api.ITexturedItem;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.RebornCore;
 import techreborn.client.TechRebornCreativeTab;
+import techreborn.compat.CompatManager;
 import techreborn.lib.ModInfo;
 
 public class ItemTreeTap extends Item implements ITexturedItem {
@@ -19,6 +28,20 @@ public class ItemTreeTap extends Item implements ITexturedItem {
 		setUnlocalizedName("techreborn.treetap");
 		RebornCore.jsonDestroyer.registerObject(this);
 		setCreativeTab(TechRebornCreativeTab.instance);
+	}
+
+
+	@Override
+	public EnumActionResult onItemUse(ItemStack stack, EntityPlayer playerIn, World worldIn, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
+		IBlockState state = worldIn.getBlockState(pos);
+		Block block = state.getBlock();
+		if(CompatManager.isIC2Loaded && block == Block.getBlockFromName("ic2:rubber_wood"))  {
+			ItemTreetap.attemptExtract(playerIn, worldIn, pos, side, state, null);
+			if (!worldIn.isRemote)
+				stack.damageItem(1, playerIn);
+			return EnumActionResult.SUCCESS;
+		}
+		return EnumActionResult.PASS;
 	}
 
 	@Override


### PR DESCRIPTION
Changes:
- The dependency of IC2 have been updated to the last version
- This implementation follow the original treetap logic but use
TechReborn original electrical cost.