### PR TITLE
Add fluidstack info to jei recipe for IndustrialGrinder

### DIFF
--- a/src/main/java/techreborn/compat/jei/industrialGrinder/IndustrialGrinderRecipeWrapper.java
+++ b/src/main/java/techreborn/compat/jei/industrialGrinder/IndustrialGrinderRecipeWrapper.java
@@ -4,6 +4,7 @@ import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.IJeiHelpers;
 import mezz.jei.api.gui.IDrawableAnimated;
 import mezz.jei.api.gui.IDrawableStatic;
+import mezz.jei.api.ingredients.IIngredients;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.fluids.FluidStack;
 import techreborn.api.recipe.machines.IndustrialGrinderRecipe;
@@ -29,6 +30,12 @@ public class IndustrialGrinderRecipeWrapper extends BaseRecipeWrapper<Industrial
 		int ticksPerCycle = baseRecipe.tickTime();
 		this.progress = guiHelper.createAnimatedDrawable(progressStatic, ticksPerCycle,
 			IDrawableAnimated.StartDirection.LEFT, false);
+	}
+	
+	@Override
+	public void getIngredients(@Nonnull final IIngredients ingredients) {
+		ingredients.setInput(FluidStack.class, this.baseRecipe.fluidStack);
+		super.getIngredients(ingredients);
 	}
 
 	@Override


### PR DESCRIPTION
This PR add the **fluid needed for a craft** to the IndustrialGrinder JEI recipes.

Beside the _IndustrialSawmill_, for which i haven't found **any recipes** other than minetweakers, there is no other machines inputting or ouputting fluidstacks in the mod according to my search. This is why i've made this in the form of a **specific code**.

The method _IndustrialGrinderRecipeWrapper#getFluidInputs_ is not linked to the ingredients, so i've considered wiser to not disturb the internal mechanics of the _BaseRecipeWrapper_ to make a **generic solution**.