### PR TITLE
More Energy Generators fixes

### DIFF
--- a/src/main/java/techreborn/tiles/generator/TileGasTurbine.java
+++ b/src/main/java/techreborn/tiles/generator/TileGasTurbine.java
@@ -113,7 +113,7 @@ public class TileGasTurbine extends TilePowerAcceptor implements IWrenchable, II
 				this.syncWithAll();
 		}
 
-		if (this.tank.getFluidAmount() > 0 && this.getMaxPower() - this.getEnergy() >= TileGasTurbine.euTick) {
+		if (this.tank.getFluidAmount() > 0 && tryAddingEnergy(euTick)) {
 			final Integer euPerBucket = this.fluids.get(this.tank.getFluidType().getName());
 			// float totalTicks = (float)euPerBucket / 8f; //x eu per bucket / 8
 			// eu per tick
@@ -128,7 +128,6 @@ public class TileGasTurbine extends TilePowerAcceptor implements IWrenchable, II
 			this.pendingWithdraw -= currentWithdraw;
 
 			this.tank.drain(currentWithdraw, true);
-			this.addEnergy(TileGasTurbine.euTick);
 
 			if (!this.isActive())
 				this.world.setBlockState(this.getPos(),
@@ -136,6 +135,7 @@ public class TileGasTurbine extends TilePowerAcceptor implements IWrenchable, II
 		} else if (this.isActive())
 			this.world.setBlockState(this.getPos(),
 					this.world.getBlockState(this.getPos()).withProperty(BlockMachineBase.ACTIVE, false));
+		
 		if (this.tank.getFluidType() != null && this.getStackInSlot(2) == ItemStack.EMPTY) {
 			this.inventory.setInventorySlotContents(2, new ItemStack(this.tank.getFluidType().getBlock()));
 		} else if (this.tank.getFluidType() == null && this.getStackInSlot(2) != ItemStack.EMPTY) {
@@ -143,6 +143,21 @@ public class TileGasTurbine extends TilePowerAcceptor implements IWrenchable, II
 		}
 	}
 
+	private boolean tryAddingEnergy(int amount)
+	{
+		if(this.getMaxPower() - this.getEnergy() >= amount)
+		{
+			addEnergy(amount);
+			return true;
+		}
+		else if(this.getMaxPower() - this.getEnergy() > 0)
+		{
+			addEnergy(this.getMaxPower() - this.getEnergy());
+			return true;
+		}
+		return false;
+	}
+	
 	@Override
 	public double getMaxPower() {
 		return ConfigTechReborn.ThermalGeneratorCharge;

--- a/src/main/java/techreborn/tiles/generator/TileSemifluidGenerator.java
+++ b/src/main/java/techreborn/tiles/generator/TileSemifluidGenerator.java
@@ -119,7 +119,7 @@ public class TileSemifluidGenerator extends TilePowerAcceptor implements IWrench
 				this.syncWithAll();
 		}
 
-		if (tank.getFluidAmount() > 0 && getMaxPower() - getEnergy() >= euTick && tank.getFluidType() != null && fluids.containsKey(tank.getFluidType().getName())) {
+		if (tank.getFluidAmount() > 0 && tank.getFluidType() != null && fluids.containsKey(tank.getFluidType().getName()) && tryAddingEnergy(euTick)) {
 			Integer euPerBucket = fluids.get(tank.getFluidType().getName());
 			// float totalTicks = (float)euPerBucket / 8f; //x eu per bucket / 8
 			// eu per tick
@@ -133,7 +133,6 @@ public class TileSemifluidGenerator extends TilePowerAcceptor implements IWrench
 			pendingWithdraw -= currentWithdraw;
 
 			tank.drain(currentWithdraw, true);
-			addEnergy(euTick);
 			if(!this.isActive())
 				this.world.setBlockState(this.getPos(),
 						this.world.getBlockState(this.getPos()).withProperty(BlockMachineBase.ACTIVE, true));
@@ -146,6 +145,21 @@ public class TileSemifluidGenerator extends TilePowerAcceptor implements IWrench
 		} else if (tank.getFluidType() == null && getStackInSlot(2) != ItemStack.EMPTY) {
 			setInventorySlotContents(2, ItemStack.EMPTY);
 		}
+	}
+	
+	private boolean tryAddingEnergy(int amount)
+	{
+		if(this.getMaxPower() - this.getEnergy() >= amount)
+		{
+			addEnergy(amount);
+			return true;
+		}
+		else if(this.getMaxPower() - this.getEnergy() > 0)
+		{
+			addEnergy(this.getMaxPower() - this.getEnergy());
+			return true;
+		}
+		return false;
 	}
 
 	@Override

--- a/src/main/java/techreborn/tiles/generator/TileThermalGenerator.java
+++ b/src/main/java/techreborn/tiles/generator/TileThermalGenerator.java
@@ -108,16 +108,18 @@ public class TileThermalGenerator extends TilePowerAcceptor implements IWrenchab
 								this.getPos().getY() + direction.getFrontOffsetY(),
 								this.getPos().getZ() + direction.getFrontOffsetZ()))
 						.getBlock() == Blocks.LAVA) {
-					this.addEnergy(1);
-					this.lastOutput = this.world.getTotalWorldTime();
+					if(this.tryAddingEnergy(1))
+						this.lastOutput = this.world.getTotalWorldTime();
 				}
 			}
 		}
 
-		if (this.tank.getFluidAmount() > 0 && this.getMaxPower() - this.getEnergy() >= TileThermalGenerator.euTick) {
-			this.tank.drain(1, true);
-			this.addEnergy(TileThermalGenerator.euTick);
-			this.lastOutput = this.world.getTotalWorldTime();
+		if (this.tank.getFluidAmount() > 0) {
+			if(tryAddingEnergy(euTick))
+			{
+				this.tank.drain(1, true);
+				this.lastOutput = this.world.getTotalWorldTime();
+			}
 		}
 
 		if (!this.world.isRemote) {
@@ -134,6 +136,21 @@ public class TileThermalGenerator extends TilePowerAcceptor implements IWrenchab
 		} else if (this.tank.getFluidType() == null && this.getStackInSlot(2) != ItemStack.EMPTY) {
 			this.inventory.setInventorySlotContents(2, ItemStack.EMPTY);
 		}
+	}
+	
+	private boolean tryAddingEnergy(int amount)
+	{
+		if(this.getMaxPower() - this.getEnergy() >= amount)
+		{
+			addEnergy(amount);
+			return true;
+		}
+		else if(this.getMaxPower() - this.getEnergy() > 0)
+		{
+			addEnergy(this.getMaxPower() - this.getEnergy());
+			return true;
+		}
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
In this PR the changes are **heavily fragmented** in **individual commits**.

- It fix a **continuous activation** with ThermalGenerator if a lava block was adjacent.

- It add a **convenience method** tryAddEnergy(amount) to generators, this method will prevent activation if the Generator is full and fill it to it's real maximum.
The old method was doing that CURRENT + ADD > MAX ? NOT_ADDING : ADDING(ADD) and would make theses weird max values : 393/400.

- It fix the HeatGenerator and DragonEggSiphoner **activation state change**.

- I've also **cleaned up** the HeatGenerator adjacents blocks detection.