### PR TITLE
add dustAsh oreDict recipe

### DIFF
--- a/src/main/java/techreborn/init/OreDict.java
+++ b/src/main/java/techreborn/init/OreDict.java
@@ -99,6 +99,7 @@ public class OreDict {
 		OreDictionary.registerOre("materialRubber", ItemParts.getPartByName("rubber"));
 		OreDictionary.registerOre("itemRubber", ItemParts.getPartByName("rubber"));
 		OreDictionary.registerOre("pulpWood", ItemDusts.getDustByName("saw_dust"));
+		OreDictionary.registerOre("dustAsh", ItemDusts.getDustByName("ashes"));
 
 		for (String type : ItemGems.types) {
 			if (type.equals(ModItems.META_PLACEHOLDER))


### PR DESCRIPTION
Embers uses dustAsh instead of dustAshes for their Ash oreDictionary. This will make TechReborn ash work with Embers.