### PR TITLE
Fix missing names in GUI machines

### DIFF
--- a/src/main/java/techreborn/client/gui/GuiAESU.java
+++ b/src/main/java/techreborn/client/gui/GuiAESU.java
@@ -77,7 +77,7 @@ public class GuiAESU extends GuiContainer {
 	}
 
 	protected void drawGuiContainerForegroundLayer(int p_146979_1_, int p_146979_2_) {
-		this.fontRenderer.drawString(I18n.translateToLocal("tile.techreborn.aesu.name"), 40, 10,
+		this.fontRenderer.drawString(I18n.translateToLocal("tile.techreborn:adjustable_su.name"), 40, 10,
 			Color.WHITE.getRGB());
 		this.fontRenderer.drawString(PowerSystem.getLocaliszedPower(containerAesu.euOut) + " /tick", 10, 20,
 			Color.WHITE.getRGB());

--- a/src/main/java/techreborn/client/gui/GuiAlloyFurnace.java
+++ b/src/main/java/techreborn/client/gui/GuiAlloyFurnace.java
@@ -70,7 +70,7 @@ public class GuiAlloyFurnace extends GuiContainer {
 
 	@Override
 	protected void drawGuiContainerForegroundLayer(final int p_146979_1_, final int p_146979_2_) {
-		final String name = I18n.translateToLocal("tile.techreborn.alloyfurnace.name");
+		final String name = I18n.translateToLocal("tile.techreborn:iron_alloy_furnace.name");
 		this.fontRenderer.drawString(name, this.xSize / 2 - this.fontRenderer.getStringWidth(name) / 2, 6,
 			4210752);
 		this.fontRenderer.drawString(I18n.translateToLocalFormatted("container.inventory", new Object[0]), 8,

--- a/src/main/java/techreborn/client/gui/GuiAlloySmelter.java
+++ b/src/main/java/techreborn/client/gui/GuiAlloySmelter.java
@@ -75,7 +75,7 @@ public class GuiAlloySmelter extends GuiContainer {
 
 	@Override
 	protected void drawGuiContainerForegroundLayer(final int p_146979_1_, final int p_146979_2_) {
-		final String name = I18n.translateToLocal("tile.techreborn.alloysmelter.name");
+		final String name = I18n.translateToLocal("tile.techreborn:alloy_smelter.name");
 		this.fontRenderer.drawString(name, this.xSize / 2 - this.fontRenderer.getStringWidth(name) / 2, 6,
 			4210752);
 		this.fontRenderer.drawString(I18n.translateToLocalFormatted("container.inventory", new Object[0]), 8,

--- a/src/main/java/techreborn/client/gui/GuiAssemblingMachine.java
+++ b/src/main/java/techreborn/client/gui/GuiAssemblingMachine.java
@@ -75,7 +75,7 @@ public class GuiAssemblingMachine extends GuiContainer {
 
 	@Override
 	protected void drawGuiContainerForegroundLayer(final int p_146979_1_, final int p_146979_2_) {
-		final String name = I18n.translateToLocal("tile.techreborn.assemblinmachine.name");
+		final String name = I18n.translateToLocal("tile.techreborn:assembly_machine.name");
 		this.fontRenderer.drawString(name, this.xSize / 2 - this.fontRenderer.getStringWidth(name) / 2, 6,
 			4210752);
 		this.fontRenderer.drawString(I18n.translateToLocalFormatted("container.inventory", new Object[0]), 8,

--- a/src/main/java/techreborn/client/gui/GuiChunkLoader.java
+++ b/src/main/java/techreborn/client/gui/GuiChunkLoader.java
@@ -77,7 +77,7 @@ public class GuiChunkLoader extends GuiContainer {
 
 	@Override
 	protected void drawGuiContainerForegroundLayer(final int p_146979_1_, final int p_146979_2_) {
-		final String name = I18n.translateToLocal("tile.techreborn.chunkloader.name");
+		final String name = I18n.translateToLocal("tile.techreborn:chunk_loader.name");
 		this.fontRenderer.drawString(name, this.xSize / 2 - this.fontRenderer.getStringWidth(name) / 2, 6,
 			4210752);
 		this.fontRenderer.drawString(I18n.translateToLocalFormatted("container.inventory", new Object[0]), 8,

--- a/src/main/java/techreborn/client/gui/GuiDieselGenerator.java
+++ b/src/main/java/techreborn/client/gui/GuiDieselGenerator.java
@@ -57,7 +57,7 @@ public class GuiDieselGenerator extends GuiContainer {
 
 	@Override
 	protected void drawGuiContainerForegroundLayer(final int p_146979_1_, final int p_146979_2_) {
-		final String name = I18n.translateToLocal("tile.techreborn.dieselgenerator.name");
+		final String name = I18n.translateToLocal("techreborn.jei.category.generator.diesel");
 		this.fontRenderer.drawString(name, this.xSize / 2 - this.fontRenderer.getStringWidth(name) / 2, 6,
 			4210752);
 		this.fontRenderer.drawString(I18n.translateToLocalFormatted("container.inventory", new Object[0]), 8,

--- a/src/main/java/techreborn/client/gui/GuiFusionReactor.java
+++ b/src/main/java/techreborn/client/gui/GuiFusionReactor.java
@@ -56,7 +56,7 @@ public class GuiFusionReactor extends GuiContainer {
 
 	@Override
 	protected void drawGuiContainerForegroundLayer(final int p_146979_1_, final int p_146979_2_) {
-		final String name = I18n.translateToLocal("tile.techreborn.fusioncontrolcomputer.name");
+		final String name = I18n.translateToLocal("tile.techreborn:fusion_control_computer.name");
 		this.fontRenderer.drawString(name, 87, 6, 4210752);
 		this.fontRenderer.drawString(I18n.translateToLocalFormatted("container.inventory", new Object[0]), 8,
 			this.ySize - 96 + 2, 4210752);

--- a/src/main/java/techreborn/client/gui/GuiImplosionCompressor.java
+++ b/src/main/java/techreborn/client/gui/GuiImplosionCompressor.java
@@ -79,7 +79,7 @@ public class GuiImplosionCompressor extends GuiContainer {
 
 	@Override
 	protected void drawGuiContainerForegroundLayer(final int p_146979_1_, final int p_146979_2_) {
-		final String name = I18n.translateToLocal("tile.techreborn.implosioncompressor.name");
+		final String name = I18n.translateToLocal("tile.techreborn:implosion_compressor.name");
 		this.fontRenderer.drawString(name, this.xSize / 2 - this.fontRenderer.getStringWidth(name) / 2, 6, 4210752);
 		this.fontRenderer.drawString(I18n.translateToLocalFormatted("container.inventory", new Object[0]), 8, this.ySize - 96 + 2, 4210752);
 	}

--- a/src/main/java/techreborn/client/gui/GuiIndustrialElectrolyzer.java
+++ b/src/main/java/techreborn/client/gui/GuiIndustrialElectrolyzer.java
@@ -75,7 +75,7 @@ public class GuiIndustrialElectrolyzer extends GuiContainer {
 
 	@Override
 	protected void drawGuiContainerForegroundLayer(final int p_146979_1_, final int p_146979_2_) {
-		final String name = I18n.translateToLocal("tile.techreborn.industrialelectrolyzer.name");
+		final String name = I18n.translateToLocal("tile.techreborn:industrial_electrolyzer.name");
 		this.fontRenderer.drawString(name, this.xSize / 2 - this.fontRenderer.getStringWidth(name) / 2, 6,
 			4210752);
 		this.fontRenderer.drawString(I18n.translateToLocalFormatted("container.inventory", new Object[0]), 8,

--- a/src/main/java/techreborn/client/gui/GuiIndustrialSawmill.java
+++ b/src/main/java/techreborn/client/gui/GuiIndustrialSawmill.java
@@ -109,7 +109,7 @@ public class GuiIndustrialSawmill extends GuiContainer {
 
 	@Override
 	protected void drawGuiContainerForegroundLayer(final int p_146979_1_, final int p_146979_2_) {
-		final String name = I18n.translateToLocal("tile.techreborn.industrialsawmill.name");
+		final String name = I18n.translateToLocal("tile.techreborn:industrial_sawmill.name");
 		this.fontRenderer.drawString(name, this.xSize / 2 - this.fontRenderer.getStringWidth(name) / 2, 6, 4210752);
 		this.fontRenderer.drawString(I18n.translateToLocalFormatted("container.inventory"), 58, this.ySize - 96 + 2, 4210752);
 	}

--- a/src/main/java/techreborn/client/gui/GuiIronFurnace.java
+++ b/src/main/java/techreborn/client/gui/GuiIronFurnace.java
@@ -68,7 +68,7 @@ public class GuiIronFurnace extends GuiContainer {
 
 	@Override
 	protected void drawGuiContainerForegroundLayer(final int p_146979_1_, final int p_146979_2_) {
-		final String name = I18n.translateToLocal("tile.techreborn.ironfurnace.name");
+		final String name = I18n.translateToLocal("tile.techreborn:iron_furnace.name");
 		this.fontRenderer.drawString(name, this.xSize / 2 - this.fontRenderer.getStringWidth(name) / 2, 6,
 			4210752);
 		this.fontRenderer.drawString(I18n.translateToLocalFormatted("container.inventory", new Object[0]), 8,

--- a/src/main/java/techreborn/client/gui/GuiLESU.java
+++ b/src/main/java/techreborn/client/gui/GuiLESU.java
@@ -61,7 +61,7 @@ public class GuiLESU extends GuiContainer {
 	}
 
 	protected void drawGuiContainerForegroundLayer(int p_146979_1_, int p_146979_2_) {
-		this.fontRenderer.drawString(I18n.translateToLocal("tile.techreborn.lesu.name"), 40, 10,
+		this.fontRenderer.drawString(I18n.translateToLocal("tile.techreborn:lapotronic_su.name"), 40, 10,
 			Color.WHITE.getRGB());
 		this.fontRenderer.drawString(PowerSystem.getLocaliszedPower(containerLesu.euOut) + "/t", 10, 20,
 			Color.WHITE.getRGB());

--- a/src/main/java/techreborn/client/gui/GuiQuantumTank.java
+++ b/src/main/java/techreborn/client/gui/GuiQuantumTank.java
@@ -56,7 +56,7 @@ public class GuiQuantumTank extends GuiContainer {
 
 	@Override
 	protected void drawGuiContainerForegroundLayer(final int p_146979_1_, final int p_146979_2_) {
-		final String name = I18n.translateToLocal("tile.techreborn.quantumTank.name");
+		final String name = I18n.translateToLocal("tile.techreborn:quantum_tank.name");
 		this.fontRenderer.drawString(name, this.xSize / 2 - this.fontRenderer.getStringWidth(name) / 2, 6,
 			4210752);
 		this.fontRenderer.drawString(I18n.translateToLocalFormatted("container.inventory", new Object[0]), 8,

--- a/src/main/java/techreborn/client/gui/GuiRollingMachine.java
+++ b/src/main/java/techreborn/client/gui/GuiRollingMachine.java
@@ -64,7 +64,7 @@ public class GuiRollingMachine extends GuiContainer {
 
 	@Override
 	protected void drawGuiContainerForegroundLayer(final int p_146979_1_, final int p_146979_2_) {
-		final String name = I18n.translateToLocal("tile.techreborn.rollingmachine.name");
+		final String name = I18n.translateToLocal("tile.techreborn:rolling_machine.name");
 		this.fontRenderer.drawString(name, this.xSize / 2 - this.fontRenderer.getStringWidth(name) / 2, 6,
 			4210752);
 		this.fontRenderer.drawString(I18n.translateToLocalFormatted("container.inventory", new Object[0]), 8,

--- a/src/main/java/techreborn/client/gui/GuiScrapboxinator.java
+++ b/src/main/java/techreborn/client/gui/GuiScrapboxinator.java
@@ -69,7 +69,7 @@ public class GuiScrapboxinator extends GuiContainer {
 
 	@Override
 	protected void drawGuiContainerForegroundLayer(final int p_146979_1_, final int p_146979_2_) {
-		final String name = net.minecraft.util.text.translation.I18n.translateToLocal("tile.techreborn.scrapboxinator.name");
+		final String name = net.minecraft.util.text.translation.I18n.translateToLocal("tile.techreborn:scrapboxinator.name");
 		this.fontRenderer.drawString(name, this.xSize / 2 - this.fontRenderer.getStringWidth(name) / 2, 6,
 			4210752);
 		this.fontRenderer.drawString(I18n.format("container.inventory", new Object[0]), 8, this.ySize - 96 + 2,

--- a/src/main/java/techreborn/client/gui/GuiThermalGenerator.java
+++ b/src/main/java/techreborn/client/gui/GuiThermalGenerator.java
@@ -58,7 +58,7 @@ public class GuiThermalGenerator extends GuiContainer {
 
 	@Override
 	protected void drawGuiContainerForegroundLayer(final int p_146979_1_, final int p_146979_2_) {
-		final String name = I18n.translateToLocal("tile.techreborn.thermalGenerator.name");
+		final String name = I18n.translateToLocal("tile.techreborn:thermal_generator.name");
 		this.fontRenderer.drawString(name, this.xSize / 2 - this.fontRenderer.getStringWidth(name) / 2, 6,
 			4210752);
 		this.fontRenderer.drawString(I18n.translateToLocalFormatted("container.inventory", new Object[0]), 8,


### PR DESCRIPTION
The desync in the names between the block and the GUI is eliminated:
- Thermal Generator
- Quantum Tank
- Rolling Machine
- Alloy Smelter
- Implosion Compressor
- Chunk Loader
- Assembling Machine
- Disel Generator
- Industrial Electrolyzer
- Iron Alloy Furnace
- Iron Furnace
- Adjustable SU (AESU)
- Lapotronic SU (LESU)
- Fusion Control Computer
- Sawmill
- Scrapbox-inator