### PR TITLE
Don't place a block when opening energy store GUI.

### DIFF
--- a/src/main/java/techreborn/blocks/storage/BlockEnergyStorage.java
+++ b/src/main/java/techreborn/blocks/storage/BlockEnergyStorage.java
@@ -107,6 +107,7 @@ public abstract class BlockEnergyStorage extends BaseTileBlock {
 			}
 		} else if (!player.isSneaking()){
 			player.openGui(Core.INSTANCE, guiID, world, pos.getX(), pos.getY(), pos.getZ());
+			return true;
 		}
 
 		return super.onBlockActivated(world, pos, state, player, hand, side, hitX, hitY, hitZ);


### PR DESCRIPTION
Currently right clicking an energy storage block with another block in hand places the block and also opens the energy storage GUI.