### PR TITLE
Advanced Jackhammer Recipe

### DIFF
--- a/src/main/java/techreborn/init/ModItems.java
+++ b/src/main/java/techreborn/init/ModItems.java
@@ -224,7 +224,7 @@ public class ModItems {
 		DIAMOND_JACKHAMMER = new ItemDiamondJackhammer();
 		registerItem(DIAMOND_JACKHAMMER, "diamondjackhammer");
 		ADVANCED_JACKHAMMER = new ItemAdvancedJackhammer();
-		registerItem(ADVANCED_JACKHAMMER, "ironjackhammer");
+		registerItem(ADVANCED_JACKHAMMER, "advancedjackhammer");
 
 		if (ConfigTechReborn.enableGemArmorAndTools) {
 			BRONZE_SWORD = new ItemTRSword(Reference.BRONZE, "ingotBronze");

--- a/src/main/java/techreborn/init/recipes/CraftingTableRecipes.java
+++ b/src/main/java/techreborn/init/recipes/CraftingTableRecipes.java
@@ -77,7 +77,7 @@ public class CraftingTableRecipes extends RecipeMethods {
 		registerShaped(getStack(ModItems.ADVANCED_CHAINSAW), " NI", "OCN", "DO ", 'I', "plateIridiumAlloy", 'N', "nuggetIridium", 'D', getStack(ModItems.DIAMOND_CHAINSAW, 1, OreDictionary.WILDCARD_VALUE), 'C', "circuitMaster", 'O', getMaterial("overclock", Type.UPGRADE));
 		registerShaped(getStack(ModItems.STEEL_JACKHAMMER), "SBS", "SCS", " S ", 'S', "ingotSteel", 'C', "circuitBasic", 'B', "reBattery");
 		registerShaped(getStack(ModItems.DIAMOND_JACKHAMMER), "DSD", "TCT", " D ", 'D', "gemDiamond", 'C', "circuitAdvanced", 'S', getStack(ModItems.STEEL_JACKHAMMER, 1, OreDictionary.WILDCARD_VALUE), 'T', "ingotTitanium");
-		registerShaped(getStack(ModItems.ADVANCED_JACKHAMMER), "NDN", "OCO", " I ", 'I', "plateIridiumAlloy", 'N', "nuggetIridium", 'D', getStack(ModItems.DIAMOND_DRILL, 1, OreDictionary.WILDCARD_VALUE), 'C', "circuitMaster", 'O', getMaterial("overclock", Type.UPGRADE));
+		registerShaped(getStack(ModItems.ADVANCED_JACKHAMMER), "NDN", "OCO", " I ", 'I', "plateIridiumAlloy", 'N', "nuggetIridium", 'D', getStack(ModItems.DIAMOND_JACKHAMMER, 1, OreDictionary.WILDCARD_VALUE), 'C', "circuitMaster", 'O', getMaterial("overclock", Type.UPGRADE));
 		registerShaped(getStack(ModItems.CLOAKING_DEVICE), "CIC", "IOI", "CIC", 'C', "ingotChrome", 'I', "plateIridiumAlloy", 'O', getStack(ModItems.LAPOTRONIC_ORB));
 		registerShaped(getStack(ModItems.LAPOTRONIC_ORB_PACK), "FOF", "SPS", "FIF", 'F', "circuitMaster", 'O', getStack(ModItems.LAPOTRONIC_ORB), 'S', "craftingSuperconductor", 'I', "ingotIridium", 'P', getStack(ModItems.LITHIUM_BATTERY_PACK));
 


### PR DESCRIPTION
During the "Great Refactoring" the crafting recipe for the advanced jackhammer was not correctly entered. The current version has a diamond drill in place of a diamond jackhammer to upgrade to the advanced. See commit 6d931b232d0670a8ccabab5fc596177312b5a8c0 for the original recipe on line src/main/java/techreborn/init/ModRecipes.java:966. Which ended up at src/main/java/techreborn/init/recipes/CraftingTableRecipes.java:80 after the refactoring. The name of the advanced jackhammer also sticks out as it is "ironjackhammer" as opposed to the expected "advancedjackhammer"

I recommend two changes:

1.  Correcting the recipe
2.  Correcting the name of the advanced jackhammer to be "advancedjackhammer"

Renaming "ironjackhammer" => "advancedjackhammer" is a potentially breaking change if any mod packs or texture packs refer to the item by name. However I judge this to be unlikely. I have grep'ed this repository and find no other references to "ironjackhammer".