### PR TITLE
Fusion reactor consumes resources. Fixes #1551

### DIFF
--- a/src/main/java/techreborn/tiles/fusionReactor/TileFusionControlComputer.java
+++ b/src/main/java/techreborn/tiles/fusionReactor/TileFusionControlComputer.java
@@ -259,6 +259,10 @@ public class TileFusionControlComputer extends TilePowerAcceptor
 					}
 					if (this.validateReactorRecipe(this.currentRecipe)) {
 						this.crafingTickTime = 0;
+						this.decrStackSize(this.topStackSlot, this.currentRecipe.getTopInput().getCount());
+						if (!this.currentRecipe.getBottomInput().isEmpty()) {
+							this.decrStackSize(this.bottomStackSlot, this.currentRecipe.getBottomInput().getCount());
+						}
 					} else {
 						this.resetCrafter();
 					}


### PR DESCRIPTION
Manually tested. Corrected by consuming the resources when the machine restarts the crafting cycle.