### PR TITLE
Remove almost all explicit uses of CapabilityEnergy.ENERGY

### DIFF
--- a/src/main/java/techreborn/blocks/BlockRubberLog.java
+++ b/src/main/java/techreborn/blocks/BlockRubberLog.java
@@ -41,10 +41,10 @@ import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import prospector.shootingstar.ShootingStar;
 import prospector.shootingstar.model.ModelCompound;
+import reborncore.common.powerSystem.forge.ForgePowerItemManager;
 import reborncore.common.util.WorldUtils;
 import techreborn.events.TRRecipeHandler;
 import techreborn.init.ModSounds;
@@ -172,7 +172,7 @@ public class BlockRubberLog extends Block {
 		}
 		IEnergyStorage capEnergy = null;
 		if (stack.getItem() instanceof ItemElectricTreetap) {
-			capEnergy = stack.getCapability(CapabilityEnergy.ENERGY, null);
+			capEnergy = new ForgePowerItemManager(stack);
 		}
 		if ((capEnergy != null && capEnergy.getEnergyStored() > 20) || stack.getItem() instanceof ItemTreeTap) {
 			if (state.getValue(HAS_SAP) && state.getValue(SAP_SIDE) == side) {

--- a/src/main/java/techreborn/events/StackToolTipEvent.java
+++ b/src/main/java/techreborn/events/StackToolTipEvent.java
@@ -31,7 +31,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.item.Item;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -45,6 +44,7 @@ import reborncore.api.IListInfoProvider;
 import reborncore.api.power.IEnergyItemInfo;
 import reborncore.common.RebornCoreConfig;
 import reborncore.common.powerSystem.PowerSystem;
+import reborncore.common.powerSystem.forge.ForgePowerItemManager;
 import reborncore.common.util.StringUtils;
 import techreborn.Core;
 
@@ -61,7 +61,7 @@ public class StackToolTipEvent {
 		List<String> tooltip = event.getToolTip();
 		
 		if (item instanceof IEnergyItemInfo) {
-			IEnergyStorage capEnergy = event.getItemStack().getCapability(CapabilityEnergy.ENERGY, null);
+			IEnergyStorage capEnergy = new ForgePowerItemManager(event.getItemStack());
 			tooltip.add(1,
 					TextFormatting.GOLD + PowerSystem.getLocaliszedPowerFormattedNoSuffix(capEnergy.getEnergyStored() / RebornCoreConfig.euPerFU)
 					+ "/" + PowerSystem.getLocaliszedPowerFormattedNoSuffix(capEnergy.getMaxEnergyStored() / RebornCoreConfig.euPerFU)

--- a/src/main/java/techreborn/items/armor/ItemCloakingDevice.java
+++ b/src/main/java/techreborn/items/armor/ItemCloakingDevice.java
@@ -34,7 +34,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.NonNullList;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -79,7 +78,7 @@ public class ItemCloakingDevice extends ItemTRArmour implements IEnergyItemInfo 
 	
 	@Override
 	public void onArmorTick(World world, EntityPlayer player, ItemStack stack) {
-		IEnergyStorage capEnergy = stack.getCapability(CapabilityEnergy.ENERGY, null);
+		IEnergyStorage capEnergy = new ForgePowerItemManager(stack);
 		if (capEnergy != null && capEnergy.getEnergyStored() >= usage) {
 			capEnergy.extractEnergy(usage, false);
 			player.setInvisible(true);
@@ -98,7 +97,7 @@ public class ItemCloakingDevice extends ItemTRArmour implements IEnergyItemInfo 
 		}
 		ItemStack uncharged = new ItemStack(ModItems.CLOAKING_DEVICE);
 		ItemStack charged = new ItemStack(ModItems.CLOAKING_DEVICE);
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 		itemList.add(uncharged);
 		itemList.add(charged);

--- a/src/main/java/techreborn/items/armor/ItemLapotronPack.java
+++ b/src/main/java/techreborn/items/armor/ItemLapotronPack.java
@@ -34,7 +34,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.NonNullList;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.api.power.IEnergyItemInfo;
@@ -69,7 +68,7 @@ public class ItemLapotronPack extends ItemArmor implements IEnergyItemInfo {
 		}
 		ItemStack uncharged = new ItemStack(ModItems.LAPOTRONIC_ORB_PACK);
 		ItemStack charged = new ItemStack(ModItems.LAPOTRONIC_ORB_PACK);
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 		itemList.add(uncharged);
 		itemList.add(charged);

--- a/src/main/java/techreborn/items/armor/ItemLithiumBatpack.java
+++ b/src/main/java/techreborn/items/armor/ItemLithiumBatpack.java
@@ -65,10 +65,18 @@ public class ItemLithiumBatpack extends ItemArmor implements IEnergyItemInfo {
 		if (world.isRemote) {
 			return;
 		}
-		if (!itemStack.hasCapability(CapabilityEnergy.ENERGY, null)) {
-			return;
-		}
-		IEnergyStorage capEnergy = itemStack.getCapability(CapabilityEnergy.ENERGY, null);
+
+		// TODO: Find out how to become compatible with IC2 items
+		// IC2 handles battery pack charging in a very peculiar way. Battery packs do not actually distribute power on their own,
+		// rather items explicitly request charging from armor slots. The default ElectricItemManager implementation will only
+		// draw power from an IElectricItem, so items utilizing ISpecialElectricItem or IBackupElectricItemManager will not work.
+		// This means that the only way for battery armor to be 100% compatible with IC2 is to be completely managed by the
+		// ElectricItemManager. This will obviously not work. Instead, we should automatically distribute power to IC2 electric items.
+		// However, this brings up a somewhat unrelated problem: TechReborn items do not know how to explicitly pull power from IC2
+		// battery packs. Perhaps we need to add a function to ExternalPowerManager to hint that an ItemStack has discharged,
+		// which will appropriately ask IC2 battery packs for energy.
+
+		IEnergyStorage capEnergy = new ForgePowerItemManager(itemStack);
 
 		for (int i = 0; i < player.inventory.getSizeInventory(); i++) {
 			if (!player.inventory.getStackInSlot(i).isEmpty()) {
@@ -123,7 +131,7 @@ public class ItemLithiumBatpack extends ItemArmor implements IEnergyItemInfo {
 		}
 		ItemStack uncharged = new ItemStack(ModItems.LITHIUM_BATTERY_PACK);
 		ItemStack charged = new ItemStack(ModItems.LITHIUM_BATTERY_PACK);
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 		itemList.add(uncharged);
 		itemList.add(charged);

--- a/src/main/java/techreborn/items/battery/ItemBattery.java
+++ b/src/main/java/techreborn/items/battery/ItemBattery.java
@@ -31,12 +31,12 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.api.power.IEnergyItemInfo;
 import reborncore.common.powerSystem.PowerSystem;
 import reborncore.common.powerSystem.PoweredItemContainerProvider;
+import reborncore.common.powerSystem.forge.ForgePowerItemManager;
 import reborncore.common.util.ItemUtils;
 import techreborn.items.ItemTR;
 
@@ -60,7 +60,7 @@ public class ItemBattery extends ItemTR implements IEnergyItemInfo {
 			@Override
 			@SideOnly(Side.CLIENT)
 			public float apply(ItemStack stack, @Nullable World worldIn, @Nullable EntityLivingBase entityIn) {
-				if (!stack.isEmpty() && stack.getCapability(CapabilityEnergy.ENERGY, null).getEnergyStored() == 0) {
+				if (!stack.isEmpty() && new ForgePowerItemManager(stack).getEnergyStored() == 0) {
 					return 1.0F;
 				}
 				return 0.0F;

--- a/src/main/java/techreborn/items/battery/ItemEnergyCrystal.java
+++ b/src/main/java/techreborn/items/battery/ItemEnergyCrystal.java
@@ -27,7 +27,6 @@ package techreborn.items.battery;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.common.powerSystem.forge.ForgePowerItemManager;
@@ -49,7 +48,7 @@ public class ItemEnergyCrystal extends ItemBattery {
 		}
 		ItemStack stack = new ItemStack(ModItems.ENERGY_CRYSTAL);
 		ItemStack charged = stack.copy();
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(stack);

--- a/src/main/java/techreborn/items/battery/ItemLapotronCrystal.java
+++ b/src/main/java/techreborn/items/battery/ItemLapotronCrystal.java
@@ -27,7 +27,6 @@ package techreborn.items.battery;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.common.powerSystem.forge.ForgePowerItemManager;
@@ -49,7 +48,7 @@ public class ItemLapotronCrystal extends ItemBattery {
 		}
 		ItemStack stack = new ItemStack(ModItems.LAPOTRONIC_CRYSTAL);
 		ItemStack charged = stack.copy();
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(stack);

--- a/src/main/java/techreborn/items/battery/ItemLapotronicOrb.java
+++ b/src/main/java/techreborn/items/battery/ItemLapotronicOrb.java
@@ -27,7 +27,6 @@ package techreborn.items.battery;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.common.powerSystem.forge.ForgePowerItemManager;
@@ -49,7 +48,7 @@ public class ItemLapotronicOrb extends ItemBattery {
 		}
 		ItemStack stack = new ItemStack(ModItems.LAPOTRONIC_ORB);
 		ItemStack charged = stack.copy();
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(stack);

--- a/src/main/java/techreborn/items/battery/ItemLithiumBattery.java
+++ b/src/main/java/techreborn/items/battery/ItemLithiumBattery.java
@@ -27,7 +27,6 @@ package techreborn.items.battery;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.common.powerSystem.forge.ForgePowerItemManager;
@@ -48,7 +47,7 @@ public class ItemLithiumBattery extends ItemBattery {
 		}
 		ItemStack stack = new ItemStack(ModItems.LITHIUM_BATTERY);
 		ItemStack charged = stack.copy();
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(stack);

--- a/src/main/java/techreborn/items/battery/ItemReBattery.java
+++ b/src/main/java/techreborn/items/battery/ItemReBattery.java
@@ -27,7 +27,6 @@ package techreborn.items.battery;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.common.powerSystem.forge.ForgePowerItemManager;
@@ -48,7 +47,7 @@ public class ItemReBattery extends ItemBattery {
 		}
 		ItemStack stack = new ItemStack(ModItems.RE_BATTERY);
 		ItemStack charged = stack.copy();
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(stack);

--- a/src/main/java/techreborn/items/tools/ItemAdvancedChainsaw.java
+++ b/src/main/java/techreborn/items/tools/ItemAdvancedChainsaw.java
@@ -33,7 +33,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -58,7 +57,7 @@ public class ItemAdvancedChainsaw extends ItemChainsaw {
 		}
 		ItemStack stack = new ItemStack(ModItems.ADVANCED_CHAINSAW);
 		ItemStack charged = stack.copy();
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(stack);
@@ -86,7 +85,7 @@ public class ItemAdvancedChainsaw extends ItemChainsaw {
 		if (oldPos == pos) {
 			return;
 		}
-		IEnergyStorage capEnergy = stack.getCapability(CapabilityEnergy.ENERGY, null);
+		IEnergyStorage capEnergy = new ForgePowerItemManager(stack);
 		if (capEnergy.getEnergyStored() < cost) {
 			return;
 		}

--- a/src/main/java/techreborn/items/tools/ItemAdvancedDrill.java
+++ b/src/main/java/techreborn/items/tools/ItemAdvancedDrill.java
@@ -36,7 +36,6 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.common.powerSystem.forge.ForgePowerItemManager;
@@ -99,7 +98,7 @@ public class ItemAdvancedDrill extends ItemDrill {
 
 	public void breakBlock(BlockPos pos, World world, EntityPlayer playerIn, ItemStack drill) {
 		IBlockState blockState = world.getBlockState(pos);
-		drill.getCapability(CapabilityEnergy.ENERGY, null).extractEnergy(cost, false);
+		new ForgePowerItemManager(drill).extractEnergy(cost, false);
 		blockState.getBlock().harvestBlock(world, playerIn, pos, blockState, world.getTileEntity(pos), drill);
 		world.setBlockToAir(pos);
 		world.removeTileEntity(pos);
@@ -156,7 +155,7 @@ public class ItemAdvancedDrill extends ItemDrill {
 		}
 		ItemStack stack = new ItemStack(ModItems.ADVANCED_DRILL);
 		ItemStack charged = stack.copy();
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(stack);

--- a/src/main/java/techreborn/items/tools/ItemAdvancedJackhammer.java
+++ b/src/main/java/techreborn/items/tools/ItemAdvancedJackhammer.java
@@ -27,7 +27,6 @@ package techreborn.items.tools;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.common.powerSystem.forge.ForgePowerItemManager;
@@ -52,7 +51,7 @@ public class ItemAdvancedJackhammer extends ItemJackhammer {
 		}
 		ItemStack stack = new ItemStack(ModItems.ADVANCED_JACKHAMMER);
 		ItemStack charged = stack.copy();
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(stack);

--- a/src/main/java/techreborn/items/tools/ItemChainsaw.java
+++ b/src/main/java/techreborn/items/tools/ItemChainsaw.java
@@ -38,12 +38,12 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.api.power.IEnergyItemInfo;
 import reborncore.common.powerSystem.PowerSystem;
 import reborncore.common.powerSystem.PoweredItemContainerProvider;
+import reborncore.common.powerSystem.forge.ForgePowerItemManager;
 import reborncore.common.util.ItemUtils;
 import techreborn.utils.TechRebornCreativeTab;
 
@@ -71,7 +71,7 @@ public class ItemChainsaw extends ItemAxe implements IEnergyItemInfo {
 			@Override
 			@SideOnly(Side.CLIENT)
 			public float apply(ItemStack stack, @Nullable World worldIn, @Nullable EntityLivingBase entityIn) {
-				if (!stack.isEmpty() && stack.getCapability(CapabilityEnergy.ENERGY, null).getEnergyStored() >= cost
+				if (!stack.isEmpty() && new ForgePowerItemManager(stack).getEnergyStored() >= cost
 						&& entityIn != null && entityIn.getHeldItemMainhand().equals(stack)) {
 					return 1.0F;
 				}
@@ -83,7 +83,7 @@ public class ItemChainsaw extends ItemAxe implements IEnergyItemInfo {
 	// ItemAxe
 	@Override
 	public float getDestroySpeed(ItemStack stack, IBlockState state) {
-		if (stack.getCapability(CapabilityEnergy.ENERGY, null).getEnergyStored() >= cost
+		if (new ForgePowerItemManager(stack).getEnergyStored() >= cost
 				&& (state.getBlock().isToolEffective("axe", state) || state.getMaterial() == Material.WOOD)) {
 			return this.poweredSpeed;
 		} else {
@@ -96,7 +96,7 @@ public class ItemChainsaw extends ItemAxe implements IEnergyItemInfo {
 	public boolean onBlockDestroyed(ItemStack stack, World worldIn, IBlockState blockIn, BlockPos pos, EntityLivingBase entityLiving) {
 		Random rand = new Random();
 		if (rand.nextInt(EnchantmentHelper.getEnchantmentLevel(Enchantments.UNBREAKING, stack) + 1) == 0) {
-			stack.getCapability(CapabilityEnergy.ENERGY, null).extractEnergy(cost, false);
+			new ForgePowerItemManager(stack).extractEnergy(cost, false);
 		}
 		return true;
 	}

--- a/src/main/java/techreborn/items/tools/ItemDiamondChainsaw.java
+++ b/src/main/java/techreborn/items/tools/ItemDiamondChainsaw.java
@@ -29,7 +29,6 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.common.powerSystem.forge.ForgePowerItemManager;
@@ -52,7 +51,7 @@ public class ItemDiamondChainsaw extends ItemChainsaw {
 		}
 		ItemStack stack = new ItemStack(ModItems.DIAMOND_CHAINSAW);
 		ItemStack charged = stack.copy();
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(stack);

--- a/src/main/java/techreborn/items/tools/ItemDiamondDrill.java
+++ b/src/main/java/techreborn/items/tools/ItemDiamondDrill.java
@@ -29,7 +29,6 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.common.powerSystem.forge.ForgePowerItemManager;
@@ -52,7 +51,7 @@ public class ItemDiamondDrill extends ItemDrill {
 		}
 		ItemStack stack = new ItemStack(ModItems.DIAMOND_DRILL);
 		ItemStack charged = stack.copy();
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(stack);

--- a/src/main/java/techreborn/items/tools/ItemDiamondJackhammer.java
+++ b/src/main/java/techreborn/items/tools/ItemDiamondJackhammer.java
@@ -27,7 +27,6 @@ package techreborn.items.tools;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.common.powerSystem.forge.ForgePowerItemManager;
@@ -51,7 +50,7 @@ public class ItemDiamondJackhammer extends ItemJackhammer {
 		}
 		ItemStack stack = new ItemStack(ModItems.DIAMOND_JACKHAMMER);
 		ItemStack charged = stack.copy();
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(stack);

--- a/src/main/java/techreborn/items/tools/ItemDrill.java
+++ b/src/main/java/techreborn/items/tools/ItemDrill.java
@@ -35,10 +35,10 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.energy.CapabilityEnergy;
 import reborncore.api.power.IEnergyItemInfo;
 import reborncore.common.powerSystem.PowerSystem;
 import reborncore.common.powerSystem.PoweredItemContainerProvider;
+import reborncore.common.powerSystem.forge.ForgePowerItemManager;
 import reborncore.common.util.ItemUtils;
 import techreborn.utils.TechRebornCreativeTab;
 
@@ -65,7 +65,7 @@ public class ItemDrill extends ItemPickaxe implements IEnergyItemInfo {
 	// ItemPickaxe
 	@Override
 	public float getDestroySpeed(ItemStack stack, IBlockState state) {
-		if (stack.getCapability(CapabilityEnergy.ENERGY, null).getEnergyStored() < cost) {
+		if (new ForgePowerItemManager(stack).getEnergyStored() < cost) {
 			return unpoweredSpeed;
 		}
 		if (Items.WOODEN_PICKAXE.getDestroySpeed(stack, state) > 1.0F
@@ -81,7 +81,7 @@ public class ItemDrill extends ItemPickaxe implements IEnergyItemInfo {
 	public boolean onBlockDestroyed(ItemStack stack, World worldIn, IBlockState blockIn, BlockPos pos, EntityLivingBase entityLiving) {
 		Random rand = new Random();
 		if (rand.nextInt(EnchantmentHelper.getEnchantmentLevel(Enchantments.UNBREAKING, stack) + 1) == 0) {
-			stack.getCapability(CapabilityEnergy.ENERGY, null).extractEnergy(cost, false);
+			new ForgePowerItemManager(stack).extractEnergy(cost, false);
 		}
 		return true;
 	}

--- a/src/main/java/techreborn/items/tools/ItemElectricTreetap.java
+++ b/src/main/java/techreborn/items/tools/ItemElectricTreetap.java
@@ -36,7 +36,6 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -69,7 +68,7 @@ public class ItemElectricTreetap extends ItemTR implements IEnergyItemInfo {
 	@Override
 	public EnumActionResult onItemUse(EntityPlayer playerIn, World worldIn, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
 		IBlockState state = worldIn.getBlockState(pos);
-		IEnergyStorage capEnergy = playerIn.getHeldItem(hand).getCapability(CapabilityEnergy.ENERGY, null);
+		IEnergyStorage capEnergy = new ForgePowerItemManager(playerIn.getHeldItem(hand));
 		if(TechRebornAPI.ic2Helper != null && capEnergy.getEnergyStored() >= cost){
 			if(TechRebornAPI.ic2Helper.extractSap(playerIn, worldIn, pos, side, state, null) && !worldIn.isRemote){
 				capEnergy.extractEnergy(cost, false);
@@ -108,7 +107,7 @@ public class ItemElectricTreetap extends ItemTR implements IEnergyItemInfo {
 		}
 		ItemStack uncharged = new ItemStack(ModItems.ELECTRIC_TREE_TAP);
 		ItemStack charged = new ItemStack(ModItems.ELECTRIC_TREE_TAP);
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(uncharged);

--- a/src/main/java/techreborn/items/tools/ItemJackhammer.java
+++ b/src/main/java/techreborn/items/tools/ItemJackhammer.java
@@ -36,10 +36,10 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.energy.CapabilityEnergy;
 import reborncore.api.power.IEnergyItemInfo;
 import reborncore.common.powerSystem.PowerSystem;
 import reborncore.common.powerSystem.PoweredItemContainerProvider;
+import reborncore.common.powerSystem.forge.ForgePowerItemManager;
 import reborncore.common.util.ItemUtils;
 import techreborn.utils.TechRebornCreativeTab;
 import techreborn.utils.OreDictUtils;
@@ -67,7 +67,7 @@ public class ItemJackhammer extends ItemPickaxe implements IEnergyItemInfo {
 	@Override
 	public float getDestroySpeed(ItemStack stack, IBlockState state) {
 		if ((OreDictUtils.isOre(state, "stone") || state.getBlock() == Blocks.STONE)
-				&& stack.getCapability(CapabilityEnergy.ENERGY, null).getEnergyStored() >= cost) {
+				&& new ForgePowerItemManager(stack).getEnergyStored() >= cost) {
 			return efficiency;
 		} else {
 			return 0.5F;
@@ -79,7 +79,7 @@ public class ItemJackhammer extends ItemPickaxe implements IEnergyItemInfo {
 	public boolean onBlockDestroyed(ItemStack stack, World worldIn, IBlockState blockIn, BlockPos pos, EntityLivingBase entityLiving) {
 		Random rand = new Random();
 		if (rand.nextInt(EnchantmentHelper.getEnchantmentLevel(Enchantments.UNBREAKING, stack) + 1) == 0) {
-			stack.getCapability(CapabilityEnergy.ENERGY, null).extractEnergy(cost, false);
+			new ForgePowerItemManager(stack).extractEnergy(cost, false);
 		}
 		return true;
 	}
@@ -93,7 +93,7 @@ public class ItemJackhammer extends ItemPickaxe implements IEnergyItemInfo {
 	@Override
 	public boolean canHarvestBlock(final IBlockState state, final ItemStack stack) {
 		return OreDictUtils.isOre(state, "stone")
-			|| state.getMaterial() == Material.ROCK && stack.getCapability(CapabilityEnergy.ENERGY, null).getEnergyStored() >= cost;
+			|| state.getMaterial() == Material.ROCK && new ForgePowerItemManager(stack).getEnergyStored() >= cost;
 	}
 
 	@Override

--- a/src/main/java/techreborn/items/tools/ItemNanosaber.java
+++ b/src/main/java/techreborn/items/tools/ItemNanosaber.java
@@ -44,7 +44,6 @@ import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -77,7 +76,7 @@ public class ItemNanosaber extends ItemSword implements IEnergyItemInfo {
 			@SideOnly(Side.CLIENT)
 			public float apply(ItemStack stack, @Nullable World worldIn, @Nullable EntityLivingBase entityIn) {
 				if (ItemUtils.isActive(stack)) {
-					ForgePowerItemManager capEnergy = (ForgePowerItemManager) stack.getCapability(CapabilityEnergy.ENERGY, null);
+					ForgePowerItemManager capEnergy = (ForgePowerItemManager) new ForgePowerItemManager(stack);
 					if (capEnergy.getMaxEnergyStored() - capEnergy.getEnergyStored() >= 0.9	* capEnergy.getMaxEnergyStored()) {
 						return 0.5F;
 					}
@@ -91,7 +90,7 @@ public class ItemNanosaber extends ItemSword implements IEnergyItemInfo {
 	// ItemSword
 	@Override
 	public boolean hitEntity(ItemStack stack, EntityLivingBase entityliving, EntityLivingBase entityliving1) {
-		IEnergyStorage capEnergy = stack.getCapability(CapabilityEnergy.ENERGY, null);
+		IEnergyStorage capEnergy = new ForgePowerItemManager(stack);
 		if (capEnergy.getEnergyStored() >= cost) {
 			capEnergy.extractEnergy(cost, false);
 			return true;
@@ -121,7 +120,7 @@ public class ItemNanosaber extends ItemSword implements IEnergyItemInfo {
 	public ActionResult<ItemStack> onItemRightClick(final World world, final EntityPlayer player, final EnumHand hand) {
 		final ItemStack stack = player.getHeldItem(hand);
 		if (player.isSneaking()) {
-			if (stack.getCapability(CapabilityEnergy.ENERGY, null).getEnergyStored() < cost) {
+			if (new ForgePowerItemManager(stack).getEnergyStored() < cost) {
 				ChatUtils.sendNoSpamMessages(MessageIDs.nanosaberID, new TextComponentString(
 					TextFormatting.GRAY + I18n.format("techreborn.message.nanosaberEnergyErrorTo") + " "
 						+ TextFormatting.GOLD + I18n
@@ -155,7 +154,7 @@ public class ItemNanosaber extends ItemSword implements IEnergyItemInfo {
 
 	@Override
 	public void onUpdate(ItemStack stack, World worldIn, Entity entityIn, int itemSlot, boolean isSelected) {
-		if (ItemUtils.isActive(stack) && stack.getCapability(CapabilityEnergy.ENERGY, null).getEnergyStored() < cost) {
+		if (ItemUtils.isActive(stack) && new ForgePowerItemManager(stack).getEnergyStored() < cost) {
 			if(worldIn.isRemote){
 				ChatUtils.sendNoSpamMessages(MessageIDs.nanosaberID, new TextComponentString(
 					TextFormatting.GRAY + I18n.format("techreborn.message.nanosaberEnergyError") + " "
@@ -206,13 +205,13 @@ public class ItemNanosaber extends ItemSword implements IEnergyItemInfo {
 		ItemStack inactiveCharged = new ItemStack(ModItems.NANOSABER);
 		inactiveCharged.setTagCompound(new NBTTagCompound());
 		inactiveCharged.getTagCompound().setBoolean("isActive", false);
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) inactiveCharged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(inactiveCharged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		ItemStack activeCharged = new ItemStack(ModItems.NANOSABER);
 		activeCharged.setTagCompound(new NBTTagCompound());
 		activeCharged.getTagCompound().setBoolean("isActive", true);
-		ForgePowerItemManager capEnergy2 = (ForgePowerItemManager) activeCharged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy2 = new ForgePowerItemManager(activeCharged);
 		capEnergy2.setEnergyStored(capEnergy2.getMaxEnergyStored());
 
 		itemList.add(inactiveUncharged);

--- a/src/main/java/techreborn/items/tools/ItemOmniTool.java
+++ b/src/main/java/techreborn/items/tools/ItemOmniTool.java
@@ -38,7 +38,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -81,7 +80,7 @@ public class ItemOmniTool extends ItemPickaxe implements IEnergyItemInfo {
 	// ItemTool
 	@Override
 	public boolean onBlockDestroyed(ItemStack stack, World worldIn, IBlockState blockIn, BlockPos pos, EntityLivingBase entityLiving) {
-		stack.getCapability(CapabilityEnergy.ENERGY, null).extractEnergy(cost, false);
+		new ForgePowerItemManager(stack).extractEnergy(cost, false);
 		return true;
 	}
 
@@ -89,7 +88,7 @@ public class ItemOmniTool extends ItemPickaxe implements IEnergyItemInfo {
 
 	// @Override
 	// public float getDigSpeed(ItemStack stack, IBlockState state) {
-	// IEnergyStorage capEnergy = stack.getCapability(CapabilityEnergy.ENERGY, null);
+	// IEnergyStorage capEnergy = new ForgePowerItemManager(stack);
 	// if (capEnergy.getEnergyStored() >= cost) {
 	// capEnergy.extractEnergy(cost, false);
 	// return 5.0F;
@@ -108,7 +107,7 @@ public class ItemOmniTool extends ItemPickaxe implements IEnergyItemInfo {
 
 	@Override
 	public boolean hitEntity(ItemStack stack, EntityLivingBase entityliving, EntityLivingBase attacker) {
-		IEnergyStorage capEnergy = stack.getCapability(CapabilityEnergy.ENERGY, null);
+		IEnergyStorage capEnergy = new ForgePowerItemManager(stack);
 		if (capEnergy.getEnergyStored() >= hitCost) {
 			capEnergy.extractEnergy(hitCost, false);
 			entityliving.attackEntityFrom(DamageSource.causePlayerDamage((EntityPlayer) attacker), 8F);
@@ -163,7 +162,7 @@ public class ItemOmniTool extends ItemPickaxe implements IEnergyItemInfo {
 		}
 		ItemStack uncharged = new ItemStack(ModItems.OMNI_TOOL);
 		ItemStack charged = new ItemStack(ModItems.OMNI_TOOL);
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(uncharged);

--- a/src/main/java/techreborn/items/tools/ItemRockCutter.java
+++ b/src/main/java/techreborn/items/tools/ItemRockCutter.java
@@ -38,7 +38,6 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.api.power.IEnergyItemInfo;
@@ -77,7 +76,7 @@ public class ItemRockCutter extends ItemPickaxe implements IEnergyItemInfo {
 
 	@Override
 	public float getDestroySpeed(ItemStack stack, IBlockState state) {
-		if (stack.getCapability(CapabilityEnergy.ENERGY, null).getEnergyStored() < cost) {
+		if (new ForgePowerItemManager(stack).getEnergyStored() < cost) {
 			return 2F;
 		} else {
 			return Items.DIAMOND_PICKAXE.getDestroySpeed(stack, state);
@@ -89,7 +88,7 @@ public class ItemRockCutter extends ItemPickaxe implements IEnergyItemInfo {
 	public boolean onBlockDestroyed(ItemStack stack, World worldIn, IBlockState blockIn, BlockPos pos, EntityLivingBase entityLiving) {
 		Random rand = new Random();
 		if (rand.nextInt(EnchantmentHelper.getEnchantmentLevel(Enchantments.UNBREAKING, stack) + 1) == 0) {
-			stack.getCapability(CapabilityEnergy.ENERGY, null).extractEnergy(cost, false);
+			new ForgePowerItemManager(stack).extractEnergy(cost, false);
 		}
 		return true;
 	}
@@ -151,7 +150,7 @@ public class ItemRockCutter extends ItemPickaxe implements IEnergyItemInfo {
 		uncharged.addEnchantment(Enchantments.SILK_TOUCH, 1);
 		ItemStack charged = new ItemStack(ModItems.ROCK_CUTTER);
 		charged.addEnchantment(Enchantments.SILK_TOUCH, 1);
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(uncharged);

--- a/src/main/java/techreborn/items/tools/ItemSteelChainsaw.java
+++ b/src/main/java/techreborn/items/tools/ItemSteelChainsaw.java
@@ -29,7 +29,6 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.common.powerSystem.forge.ForgePowerItemManager;
@@ -52,7 +51,7 @@ public class ItemSteelChainsaw extends ItemChainsaw {
 		}
 		ItemStack stack = new ItemStack(ModItems.STEEL_CHAINSAW);
 		ItemStack charged = stack.copy();
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(stack);

--- a/src/main/java/techreborn/items/tools/ItemSteelDrill.java
+++ b/src/main/java/techreborn/items/tools/ItemSteelDrill.java
@@ -29,7 +29,6 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.common.powerSystem.forge.ForgePowerItemManager;
@@ -52,7 +51,7 @@ public class ItemSteelDrill extends ItemDrill {
 		}
 		ItemStack stack = new ItemStack(ModItems.STEEL_DRILL);
 		ItemStack charged = stack.copy();
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(stack);

--- a/src/main/java/techreborn/items/tools/ItemSteelJackhammer.java
+++ b/src/main/java/techreborn/items/tools/ItemSteelJackhammer.java
@@ -27,7 +27,6 @@ package techreborn.items.tools;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import reborncore.common.powerSystem.forge.ForgePowerItemManager;
@@ -50,7 +49,7 @@ public class ItemSteelJackhammer extends ItemJackhammer {
 		}
 		ItemStack stack = new ItemStack(ModItems.STEEL_JACKHAMMER);
 		ItemStack charged = stack.copy();
-		ForgePowerItemManager capEnergy = (ForgePowerItemManager) charged.getCapability(CapabilityEnergy.ENERGY, null);
+		ForgePowerItemManager capEnergy = new ForgePowerItemManager(charged);
 		capEnergy.setEnergyStored(capEnergy.getMaxEnergyStored());
 
 		itemList.add(stack);


### PR DESCRIPTION
As it turns out, most of the uses of `CapabilityEnergy` are Tech Reborn items accessing their own power supply. In these cases it is safe to assume that getCapability will return a ForgePowerItemManager, meaning that instead of going through the capability system items can just directly access their power supply. In some cases this eliminates a cast where the implementation already assumed it was using ForgePowerItemManager.

This makes it possible to use FE internally, while adding the possibility of not exposing FE externally. Eventually this will become useful for enabling a true EU-only mode of TechReborn, while also providing the option to have TechReborn supporting FE. 

For now, this does not add or remove any functionality, but it is simply a refactoring to open up the possibility of disabling the returning CapabilityEnergy.ENERGY from PoweredItemContainerProvider.

However, there is one hole with the changes: the Lithium Backpack and Lapotron Pack still have to use CapabilityEnergy directly since the only way to charge items through the IC2 Helper is from a TilePowerAcceptor. Therefore, I think that it would work to add another API to charge an item from a ForgePowerItemManager combo. Also, StackInfoHud and ItemUtils need to be modified in RC to use ForgePowerItemManager directly as well before CapabilityEnergy returning can be disabled.