### PR TITLE
Fix tweaker_test.js.mcmeta

### DIFF
--- a/src/main/resources/data/techreborn/tweakers/tweaker_test.js.mcmeta
+++ b/src/main/resources/data/techreborn/tweakers/tweaker_test.js.mcmeta
@@ -1,5 +1,5 @@
 {
-    "when": {
-        "libcd:dev_mode": true
-    }
+    "when": [
+        { "libcd:dev_mode": true }
+    ]
 }


### PR DESCRIPTION
I just found a bug with LibCD where a malformed condition mcmeta would cause the sample script to load in production environments. The bug is fixed with LibCD 1.4.0, but I realized that the TR `tweaker_test.js.mcmeta` is malformed in the way that causes the bug. This fixes the mcmeta so the script will actually run in dev mode.