### PR TITLE
Some REI Compat Changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,10 +81,7 @@ dependencies {
 	modCompile "net.fabricmc.fabric-api:fabric-api:0.4.1+build.245-1.14"
 
 	modCompile "io.github.prospector:modmenu:1.7.9+build.118"
-	modCompile ("me.shedaniel:RoughlyEnoughItems:3.1.8+build.35") {
-		//Thanks for moving the project breaking gradle...
-		exclude group: 'io.github.prospector.modmenu', module: 'ModMenu'
-	}
+	modCompile ("me.shedaniel:RoughlyEnoughItems:3.2.5+build.48")
 	modCompile ('io.github.cottonmc:LibCD:1.5.0+1.14.4') {
 		transitive = false
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
 	modCompile "net.fabricmc.fabric-api:fabric-api:0.4.1+build.245-1.14"
 
 	modCompile "io.github.prospector:modmenu:1.7.9+build.118"
-	modCompile ("me.shedaniel:RoughlyEnoughItems:3.2.5+build.48")
+	modCompile ("me.shedaniel:RoughlyEnoughItems:3.2.6+build.49")
 	modCompile ('io.github.cottonmc:LibCD:1.5.0+1.14.4') {
 		transitive = false
 	}

--- a/src/main/java/techreborn/compat/rei/MachineRecipeCategory.java
+++ b/src/main/java/techreborn/compat/rei/MachineRecipeCategory.java
@@ -26,6 +26,7 @@ package techreborn.compat.rei;
 
 import me.shedaniel.math.api.Point;
 import me.shedaniel.math.api.Rectangle;
+import me.shedaniel.rei.api.EntryStack;
 import me.shedaniel.rei.api.RecipeCategory;
 import me.shedaniel.rei.api.Renderer;
 import me.shedaniel.rei.gui.renderers.RecipeRenderer;
@@ -71,12 +72,13 @@ public class MachineRecipeCategory<R extends RebornRecipe> implements RecipeCate
 	}
 
 	@Override
-	public Renderer getIcon() {
-		return Renderer.fromItemStack(new ItemStack(ReiPlugin.iconMap.getOrDefault(rebornRecipeType, () -> Items.DIAMOND_SHOVEL).asItem()));
+	public EntryStack getLogo() {
+		return EntryStack.create(ReiPlugin.iconMap.getOrDefault(rebornRecipeType, () -> Items.DIAMOND_SHOVEL));
 	}
 
 	@Override
 	public RecipeRenderer getSimpleRenderer(MachineRecipeDisplay<R> recipe) {
+		// There is currently no replacement for Renderer in the 1.14 version of REI
 		return Renderer.fromRecipe(() -> Collections.singletonList(recipe.getInput().get(0)), recipe::getOutput);
 	}
 
@@ -92,37 +94,28 @@ public class MachineRecipeCategory<R extends RebornRecipe> implements RecipeCate
         widgets.add(new RecipeArrowWidget(startPoint.x + 24, startPoint.y + 1, true));
 
 		int i = 0;
-		for (List<ItemStack> inputs : machineRecipe.getInput()){
-			widgets.add(new SlotWidget(startPoint.x + 1, startPoint.y + 1 + (i++ * 20), Renderer.fromItemStacks(inputs), true, true, true));
-		}
-		
-		FluidInstance fluidInstance = machineRecipe.getFluidInstance();
-		if (fluidInstance != null) {
-			widgets.add(new SlotWidget(startPoint.x + 1, startPoint.y + 1 + (i++ * 20), Renderer.fromFluid(fluidInstance.getFluid()), true, true, true));
+		for (List<EntryStack> inputs : machineRecipe.getInputEntries()){
+			widgets.add(EntryWidget.create(startPoint.x + 1, startPoint.y + 1 + (i++ * 20)).entries(inputs));
 		}
 		
 		Text energyPerTick = new TranslatableText("techreborn.jei.recipe.running.cost", "E", machineRecipe.getEnergy());
-		widgets.add(new LabelWidget(startPoint.x + 1, startPoint.y + 1 + (i++ * 20), energyPerTick.asFormattedString()){
-			@Override
-			public void render(int mouseX, int mouseY, float delta) {
-				font.draw(text, x - font.getStringWidth(text) / 2, y, ScreenHelper.isDarkModeEnabled() ? 0xFFBBBBBB : 0xFF404040);
-			}
-		});
+		LabelWidget costLabel;
+		widgets.add(costLabel = new LabelWidget(startPoint.x + 1, startPoint.y + 1 + (i++ * 20), energyPerTick.asFormattedString()));
+		costLabel.setHasShadows(false);
+		costLabel.setDefaultColor(ScreenHelper.isDarkModeEnabled() ? 0xFFBBBBBB : 0xFF404040);
 
 		i = 0;
-		for (ItemStack outputs : machineRecipe.getOutput()){
-			widgets.add(new SlotWidget(startPoint.x + 61, startPoint.y + 1 + (i++ * 20), Renderer.fromItemStack(outputs), true, true, true));
+		for (EntryStack outputs : machineRecipe.getOutputEntries()){
+			widgets.add(EntryWidget.create(startPoint.x + 61, startPoint.y + 1 + (i++ * 20)).entry(outputs));
 		}
 		
 		int heat = machineRecipe.getHeat();
 		if (heat > 0) {
 			String neededHeat = heat + " " + StringUtils.t("techreborn.jei.recipe.heat");
-			widgets.add(new LabelWidget(startPoint.x + 61, startPoint.y + 1 + (i++ * 20), neededHeat){
-				@Override
-				public void render(int mouseX, int mouseY, float delta) {
-					font.draw(text, x - font.getStringWidth(text) / 2, y, ScreenHelper.isDarkModeEnabled() ? 0xFFBBBBBB : 0xFF404040);
-				}
-			});			
+			LabelWidget heatLabel;
+			widgets.add(heatLabel = new LabelWidget(startPoint.x + 61, startPoint.y + 1 + (i++ * 20), neededHeat));
+			heatLabel.setHasShadows(false);
+			heatLabel.setDefaultColor(ScreenHelper.isDarkModeEnabled() ? 0xFFBBBBBB : 0xFF404040);
 		}
 
 		return widgets;

--- a/src/main/java/techreborn/compat/rei/MachineRecipeDisplay.java
+++ b/src/main/java/techreborn/compat/rei/MachineRecipeDisplay.java
@@ -24,38 +24,39 @@
 
 package techreborn.compat.rei;
 
+import me.shedaniel.rei.api.EntryStack;
 import me.shedaniel.rei.api.RecipeDisplay;
-import net.minecraft.item.ItemStack;
+import me.shedaniel.rei.utils.CollectionUtils;
 import net.minecraft.util.Identifier;
-import reborncore.common.crafting.ingredient.RebornIngredient;
-import reborncore.common.fluid.container.FluidInstance;
-import techreborn.api.recipe.recipes.BlastFurnaceRecipe;
 import reborncore.common.crafting.RebornFluidRecipe;
 import reborncore.common.crafting.RebornRecipe;
+import reborncore.common.fluid.container.FluidInstance;
+import techreborn.api.recipe.recipes.BlastFurnaceRecipe;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class MachineRecipeDisplay<R extends RebornRecipe> implements RecipeDisplay {
-
+	
 	private final R recipe;
-	private List<List<ItemStack>> inputs;
-	private List<ItemStack> outputs;
+	private List<List<EntryStack>> inputs;
+	private List<EntryStack> outputs;
 	private int energy = 0;
 	private int heat = 0;
 	private FluidInstance fluidInstance = null;
-
+	
 	public MachineRecipeDisplay(R recipe) {
 		this.recipe = recipe;
-		this.inputs = recipe.getRebornIngredients().stream().map(RebornIngredient::getPreviewStacks).collect(Collectors.toList());
-		this.outputs = recipe.getOutputs();
+		this.inputs = CollectionUtils.map(recipe.getRebornIngredients(), ing -> CollectionUtils.map(ing.getPreviewStacks(), EntryStack::create));
+		this.outputs = CollectionUtils.map(recipe.getOutputs(), stack -> EntryStack.create(stack));
 		this.energy = recipe.getPower();
 		if (recipe instanceof BlastFurnaceRecipe) {
 			this.heat = ((BlastFurnaceRecipe) recipe).getHeat();
 		}
 		if (recipe instanceof RebornFluidRecipe) {
 			this.fluidInstance = ((RebornFluidRecipe) recipe).getFluidInstance();
+			inputs.add(Collections.singletonList(EntryStack.create(fluidInstance.getFluid(), fluidInstance.getAmount())));
 		}
 	}
 	
@@ -70,27 +71,27 @@ public class MachineRecipeDisplay<R extends RebornRecipe> implements RecipeDispl
 	public FluidInstance getFluidInstance() {
 		return fluidInstance;
 	}
-
+	
 	@Override
 	public Optional<Identifier> getRecipeLocation() {
 		return Optional.ofNullable(recipe).map(RebornRecipe::getId);
 	}
-
+	
 	@Override
-	public List<List<ItemStack>> getInput() {
+	public List<List<EntryStack>> getInputEntries() {
 		return inputs;
 	}
-
+	
 	@Override
-	public List<List<ItemStack>> getRequiredItems() {
+	public List<List<EntryStack>> getRequiredEntries() {
 		return inputs;
 	}
-
+	
 	@Override
-	public List<ItemStack> getOutput() {
+	public List<EntryStack> getOutputEntries() {
 		return outputs;
 	}
-
+	
 	@Override
 	public Identifier getRecipeCategory() {
 		return recipe.getRebornRecipeType().getName();

--- a/src/main/java/techreborn/compat/rei/fluidreplicator/FluidReplicatorRecipeCategory.java
+++ b/src/main/java/techreborn/compat/rei/fluidreplicator/FluidReplicatorRecipeCategory.java
@@ -24,30 +24,24 @@
 
 package techreborn.compat.rei.fluidreplicator;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.function.Supplier;
-
 import me.shedaniel.math.api.Point;
 import me.shedaniel.math.api.Rectangle;
+import me.shedaniel.rei.api.EntryStack;
 import me.shedaniel.rei.api.RecipeCategory;
-import me.shedaniel.rei.api.Renderer;
-import me.shedaniel.rei.gui.widget.LabelWidget;
-import me.shedaniel.rei.gui.widget.RecipeArrowWidget;
-import me.shedaniel.rei.gui.widget.RecipeBaseWidget;
-import me.shedaniel.rei.gui.widget.SlotWidget;
-import me.shedaniel.rei.gui.widget.Widget;
+import me.shedaniel.rei.gui.widget.*;
 import me.shedaniel.rei.impl.ScreenHelper;
-import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 import reborncore.common.crafting.RebornRecipeType;
-import reborncore.common.fluid.container.FluidInstance;
 import reborncore.common.util.StringUtils;
 import techreborn.api.recipe.recipes.FluidReplicatorRecipe;
 import techreborn.compat.rei.ReiPlugin;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Supplier;
 
 public class FluidReplicatorRecipeCategory implements RecipeCategory<FluidReplicatorRecipeDisplay> {
 	
@@ -57,52 +51,48 @@ public class FluidReplicatorRecipeCategory implements RecipeCategory<FluidReplic
 		this.rebornRecipeType = recipeType;
 		
 	}
-
+	
 	@Override
 	public Identifier getIdentifier() {
 		return rebornRecipeType.getName();
 	}
-
+	
 	@Override
 	public String getCategoryName() {
 		return StringUtils.t(rebornRecipeType.getName().toString());
 	}
-
+	
 	@Override
-	public Renderer getIcon() {
-		return Renderer.fromItemStack(new ItemStack(ReiPlugin.iconMap.getOrDefault(rebornRecipeType, () -> Items.DIAMOND_SHOVEL).asItem()));
+	public EntryStack getLogo() {
+		return EntryStack.create(ReiPlugin.iconMap.getOrDefault(rebornRecipeType, () -> Items.DIAMOND_SHOVEL));
 	}
 	
 	@Override
 	public List<Widget> setupDisplay(Supplier<FluidReplicatorRecipeDisplay> recipeDisplaySupplier, Rectangle bounds) {
-
+		
 		FluidReplicatorRecipeDisplay machineRecipe = recipeDisplaySupplier.get();
-
-		Point startPoint = new Point( bounds.getCenterX() - 41, bounds.getCenterY() - 13);
-
-        List<Widget> widgets = new LinkedList<>();
-        widgets.add(new RecipeBaseWidget(bounds));
-        widgets.add(new RecipeArrowWidget(startPoint.x + 24, startPoint.y + 1, true));
-
+		
+		Point startPoint = new Point(bounds.getCenterX() - 41, bounds.getCenterY() - 13);
+		
+		List<Widget> widgets = new LinkedList<>();
+		widgets.add(new RecipeBaseWidget(bounds));
+		widgets.add(new RecipeArrowWidget(startPoint.x + 24, startPoint.y + 1, true));
+		
 		int i = 0;
-		for (List<ItemStack> inputs : machineRecipe.getInput()){
-			widgets.add(new SlotWidget(startPoint.x + 1, startPoint.y + 1 + (i++ * 20), Renderer.fromItemStacks(inputs), true, true, true));
+		for (List<EntryStack> inputs : machineRecipe.getInputEntries()) {
+			widgets.add(EntryWidget.create(startPoint.x + 1, startPoint.y + 1 + (i++ * 20)).entries(inputs));
 		}
 		
 		Text energyPerTick = new TranslatableText("techreborn.jei.recipe.running.cost", "E", machineRecipe.getEnergy());
-		widgets.add(new LabelWidget(startPoint.x + 1, startPoint.y + 1 + (i++ * 20), energyPerTick.asFormattedString()){
-			@Override
-			public void render(int mouseX, int mouseY, float delta) {
-				font.draw(text, x - font.getStringWidth(text) / 2, y, ScreenHelper.isDarkModeEnabled() ? 0xFFBBBBBB : 0xFF404040);
-			}
-		});
-
-		FluidInstance fluidInstance = machineRecipe.getFluidInstance();
-		if (fluidInstance != null) {
-			widgets.add(new SlotWidget(startPoint.x + 61, startPoint.y + 1, Renderer.fromFluid(fluidInstance.getFluid()), true, true, true));
-		}
-	
+		LabelWidget costLabel;
+		widgets.add(costLabel = new LabelWidget(startPoint.x + 1, startPoint.y + 1 + (i++ * 20), energyPerTick.asFormattedString()));
+		costLabel.setHasShadows(false);
+		costLabel.setDefaultColor(ScreenHelper.isDarkModeEnabled() ? 0xFFBBBBBB : 0xFF404040);
+		
+		if (!machineRecipe.getOutputEntries().isEmpty())
+			widgets.add(EntryWidget.create(startPoint.x + 61, startPoint.y + 1).entries(machineRecipe.getOutputEntries()));
+		
 		return widgets;
 	}
-
+	
 }

--- a/src/main/java/techreborn/compat/rei/fluidreplicator/FluidReplicatorRecipeDisplay.java
+++ b/src/main/java/techreborn/compat/rei/fluidreplicator/FluidReplicatorRecipeDisplay.java
@@ -24,32 +24,32 @@
 
 package techreborn.compat.rei.fluidreplicator;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import reborncore.common.fluid.container.FluidInstance;
+import me.shedaniel.rei.api.EntryStack;
 import me.shedaniel.rei.api.RecipeDisplay;
-import net.minecraft.item.ItemStack;
+import me.shedaniel.rei.utils.CollectionUtils;
 import net.minecraft.util.Identifier;
-import reborncore.common.crafting.ingredient.RebornIngredient;
+import reborncore.common.fluid.container.FluidInstance;
 import techreborn.api.recipe.recipes.FluidReplicatorRecipe;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author drcrazy
- *
  */
 public class FluidReplicatorRecipeDisplay implements RecipeDisplay {
 	
 	private final FluidReplicatorRecipe recipe;
-	private List<List<ItemStack>> inputs;
+	private List<List<EntryStack>> inputs;
+	private List<EntryStack> output;
 	private FluidInstance fluidInstance;
 	private int energy = 0;
 	
 	public FluidReplicatorRecipeDisplay(FluidReplicatorRecipe recipe) {
 		this.recipe = recipe;
-		this.inputs = recipe.getRebornIngredients().stream().map(RebornIngredient::getPreviewStacks).collect(Collectors.toList());
+		this.inputs = CollectionUtils.map(recipe.getRebornIngredients(), ing -> CollectionUtils.map(ing.getPreviewStacks(), EntryStack::create));
 		this.fluidInstance = recipe.getFluidInstance();
+		this.output = fluidInstance == null ? Collections.emptyList() : Collections.singletonList(EntryStack.create(fluidInstance.getFluid(), fluidInstance.getAmount()));
 		this.energy = recipe.getPower();
 	}
 	
@@ -60,17 +60,22 @@ public class FluidReplicatorRecipeDisplay implements RecipeDisplay {
 	public int getEnergy() {
 		return energy;
 	}
-
+	
 	@Override
-	public List<List<ItemStack>> getInput() {
+	public List<List<EntryStack>> getInputEntries() {
 		return inputs;
 	}
-
+	
 	@Override
-	public List<ItemStack> getOutput() {
-		return new ArrayList<ItemStack>();
+	public List<EntryStack> getOutputEntries() {
+		return output;
 	}
-
+	
+	@Override
+	public List<List<EntryStack>> getRequiredEntries() {
+		return inputs;
+	}
+	
 	@Override
 	public Identifier getRecipeCategory() {
 		return recipe.getRebornRecipeType().getName();

--- a/src/main/java/techreborn/compat/rei/rollingmachine/RollingMachineCategory.java
+++ b/src/main/java/techreborn/compat/rei/rollingmachine/RollingMachineCategory.java
@@ -24,9 +24,8 @@
 
 package techreborn.compat.rei.rollingmachine;
 
-import me.shedaniel.rei.api.Renderer;
+import me.shedaniel.rei.api.EntryStack;
 import me.shedaniel.rei.plugin.crafting.DefaultCraftingCategory;
-import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.Identifier;
 import reborncore.common.crafting.RebornRecipeType;
@@ -35,26 +34,26 @@ import techreborn.api.recipe.recipes.RollingMachineRecipe;
 import techreborn.compat.rei.ReiPlugin;
 
 public class RollingMachineCategory extends DefaultCraftingCategory {
-
+	
 	private final RebornRecipeType<RollingMachineRecipe> rebornRecipeType;
-
+	
 	public RollingMachineCategory(RebornRecipeType<RollingMachineRecipe> rebornRecipeType) {
 		this.rebornRecipeType = rebornRecipeType;
 	}
-
+	
 	@Override
 	public Identifier getIdentifier() {
 		return rebornRecipeType.getName();
 	}
-
+	
 	@Override
 	public String getCategoryName() {
 		return StringUtils.t(rebornRecipeType.getName().toString());
 	}
-
+	
 	@Override
-	public Renderer getIcon() {
-		return Renderer.fromItemStack(new ItemStack(ReiPlugin.iconMap.getOrDefault(rebornRecipeType, () -> Items.DIAMOND_SHOVEL).asItem()));
+	public EntryStack getLogo() {
+		return EntryStack.create(ReiPlugin.iconMap.getOrDefault(rebornRecipeType, () -> Items.DIAMOND_SHOVEL));
 	}
-
+	
 }


### PR DESCRIPTION
Should fix #1854
This is a new API added in v3.2.
I plan to move forward to this API completely in 1.15 release, but I am still working out how I should implement this.
`ReiPlugin#postRegister` is the current way to fix that tag issue, it will still ignore amount but it checks the tag, I don't see it as being a good solution but it will solve it for now.
I don't really understand #1878 for now, but I speculate that it is related to that checking amount issue.
EDIT: TR will still work fine with REI 3.2 without this PR.