### PR TITLE
update to LibCD 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,10 +82,10 @@ dependencies {
 
 	modCompileOnly "io.github.prospector:modmenu:1.7.9-unstable.19w34a+build.1"
 	modCompileOnly ("me.shedaniel:RoughlyEnoughItems:3.2.7-unstable.201911150440")
-	modCompile ('io.github.cottonmc:LibCD:1.5.0+1.14.4') {
+	modCompile ('io.github.cottonmc:LibCD:2.0.1+1.15') {
 		transitive = false
 	}
-	modRuntime ("io.github.cottonmc:Jankson:1.0.0+j1.1.2") {
+	modRuntime ("io.github.cottonmc:Jankson-Fabric:2.0.0+j1.2.0") {
 		transitive = false
 	}
 

--- a/src/main/java/techreborn/TechReborn.java
+++ b/src/main/java/techreborn/TechReborn.java
@@ -91,10 +91,6 @@ public class TechReborn implements ModInitializer {
 
 		DataAttachment.REGISTRY.register(IDSUManager.class, IDSUManager::new);
 
-		if (FabricLoader.getInstance().isModLoaded("libcd")) {
-			TRTweaker.init();
-		}
-
 		LOGGER.info("TechReborn setup done!");
 
 	}

--- a/src/main/java/techreborn/compat/libcd/LibCDPlugin.java
+++ b/src/main/java/techreborn/compat/libcd/LibCDPlugin.java
@@ -1,0 +1,22 @@
+package techreborn.compat.libcd;
+
+import io.github.cottonmc.libcd.api.LibCDInitializer;
+import io.github.cottonmc.libcd.api.condition.ConditionManager;
+import io.github.cottonmc.libcd.api.tweaker.TweakerManager;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import techreborn.TechReborn;
+import techreborn.items.ItemDynamicCell;
+
+public class LibCDPlugin implements LibCDInitializer {
+	@Override
+	public void initTweakers(TweakerManager manager) {
+		manager.addTweaker("techreborn.TRTweaker", TRTweaker.INSTANCE);
+		manager.addStackFactory(new Identifier(TechReborn.MOD_ID, "cell"), (id) -> ItemDynamicCell.getCellWithFluid(Registry.FLUID.get(id)));
+	}
+
+	@Override
+	public void initConditions(ConditionManager manager) {
+
+	}
+}

--- a/src/main/java/techreborn/compat/libcd/TRRecipeParser.java
+++ b/src/main/java/techreborn/compat/libcd/TRRecipeParser.java
@@ -2,8 +2,8 @@ package techreborn.compat.libcd;
 
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import io.github.cottonmc.libcd.tweaker.TweakerSyntaxException;
-import io.github.cottonmc.libcd.tweaker.TweakerUtils;
+import io.github.cottonmc.libcd.api.CDSyntaxError;
+import io.github.cottonmc.libcd.api.tweaker.util.TweakerUtils;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.item.Item;
@@ -24,7 +24,7 @@ import java.util.Optional;
 
 public class TRRecipeParser {
 
-    public static RebornIngredient processIngredient(Object input) throws TweakerSyntaxException {
+    public static RebornIngredient processIngredient(Object input) throws CDSyntaxError {
         if (input instanceof RebornIngredient) {
             return (RebornIngredient) input;
         } else if (input instanceof Ingredient) {
@@ -42,12 +42,12 @@ public class TRRecipeParser {
                 //fluids
                 Identifier id = new Identifier(in.substring(1));
                 Fluid fluid = Registry.FLUID.get(id);
-                if (fluid == Fluids.EMPTY) throw new TweakerSyntaxException("Failed to get fluid for input: " + in);
+                if (fluid == Fluids.EMPTY) throw new CDSyntaxError("Failed to get fluid for input: " + in);
                 return new FluidIngredient(fluid, Optional.empty(), amount);
             } else if (in.indexOf('#') == 0) {
                 Identifier id = new Identifier(in.substring(1));
                 Tag<Item> itemTag = ItemTags.getContainer().get(id);
-                if (itemTag == null) throw new TweakerSyntaxException("Failed to get item tag for input: " + in);
+                if (itemTag == null) throw new CDSyntaxError("Failed to get item tag for input: " + in);
                 return new TagIngredient(id, ItemTags.getContainer().get(id), amount);
             } else {
                 ItemStack stack;
@@ -56,7 +56,7 @@ public class TRRecipeParser {
                 if (in.contains("->")) {
                     ItemStack readStack = TweakerUtils.INSTANCE.getSpecialStack(in);
                     if (readStack.isEmpty())
-                        throw new TweakerSyntaxException("Failed to get special stack for input: " + in);
+                        throw new CDSyntaxError("Failed to get special stack for input: " + in);
                     if (readStack.hasTag()) {
                         tag = Optional.of(readStack.getTag());
                     } else {
@@ -74,18 +74,18 @@ public class TRRecipeParser {
                             if (parsedTag.isEmpty()) requireEmpty = true;
                             else tag = Optional.of(reader.parseCompoundTag());
                         } catch (CommandSyntaxException e) {
-                            throw new TweakerSyntaxException(e.getMessage());
+                            throw new CDSyntaxError(e.getMessage());
                         }
                     }
                     Identifier id = new Identifier(in);
                     Item item = Registry.ITEM.get(id);
-                    if (item == Items.AIR) throw new TweakerSyntaxException("Failed to get item for input: " + in);
+                    if (item == Items.AIR) throw new CDSyntaxError("Failed to get item for input: " + in);
                     stack = new ItemStack(item);
                 }
                 return new StackIngredient(Collections.singletonList(stack), amount, tag, requireEmpty);
             }
         }
-        else throw new TweakerSyntaxException("Illegal object passed to TechReborn of type " + input.getClass().getName());
+        else throw new CDSyntaxError("Illegal object passed to TechReborn ingredient parser of type " + input.getClass().getName());
     }
 
     public static FluidInstance parseFluid(String fluid) {

--- a/src/main/resources/data/techreborn/tweakers/tweaker_test.js
+++ b/src/main/resources/data/techreborn/tweakers/tweaker_test.js
@@ -1,15 +1,18 @@
 //Warn that the sample script is running
-print("WARNING! The TechReborn tweaker sample script is running!");
-print("If you're seeing this and aren't in dev mode, please report it!");
+log.warn("WARNING! The TechReborn tweaker sample script is running!");
+log.warn("If you're seeing this and aren't in dev mode, please report it!");
+
+var TRTweaker = libcd.require("techreborn.TRTweaker");
+var TweakerUtils = libcd.require("libcd.util.TweakerUtils");
 
 //Add an alloy smelter recipe that takes 8 coal and 2 obsidian -> 2 diamonds
-TRTweaker.addAlloySmelter(["minecraft:coal@8", "minecraft:obsidian@2"], [TweakerUtils.createItemStack("minecraft:diamond", 2)], 6, 200);
+TRTweaker.addAlloySmelter(["minecraft:coal@8", "minecraft:obsidian@2"], ["minecraft:diamond@2"], 6, 200);
 
 //Add an assembling machine recipe that takes 3 diamonds and 2 sticks -> 1 diamond pickaxe
-TRTweaker.addAssemblingMachine(["minecraft:diamond@3", "minecraft:stick@2"], [TweakerUtils.createItemStack("minecraft:diamond_pickaxe", 1)], 20, 200);
+TRTweaker.addAssemblingMachine(["minecraft:diamond@3", "minecraft:stick@2"], ["minecraft:diamond_pickaxe"], 20, 200);
 
 //Add a blast furnace recipe that takes 64 of any item in the minecraft:coals tag -> 8 diamonds
-TRTweaker.addBlastFurnace(["#minecraft:coals@64"], [TweakerUtils.createItemStack("minecraft:diamond", 8)], 128, 200, 1300);
+TRTweaker.addBlastFurnace(["#minecraft:coals@64"], ["minecraft:diamond@8"], 128, 200, 1300);
 
 //Add a centrifuge recipe that takes any potion -> a water bottle
 TRTweaker.addCentrifuge(["minecraft:potion"], [TweakerUtils.getSpecialStack("minecraft:potion->minecraft:water")], 5, 1000);
@@ -19,53 +22,53 @@ TRTweaker.addCentrifuge(["minecraft:potion"], [TweakerUtils.getSpecialStack("min
 TRTweaker.addChemicalReactor(["minecraft:potion->minecraft:water", TRTweaker.createFluidIngredient("techreborn:methane", ["techreborn:cell"], -1)], [TweakerUtils.getSpecialStack("minecraft:potion->minecraft:fire_resistance")], 30, 800);
 
 //Add a compressor recipe that takes 9 coal blocks -> 3 pieces of obsidian
-TRTweaker.addCompressor(["minecraft:coal_ore@9"], [TweakerUtils.createItemStack("minecraft:coal_block", 3)], 10, 300);
+TRTweaker.addCompressor(["minecraft:coal_ore@9"], ["minecraft:coal_block@3"], 10, 300);
 
 //Add a distillation tower recipe that takes a potion of regneration -> a strong potion of regeneration
 TRTweaker.addDistillationTower(["minecraft:potion->minecraft:regeneration"], [TweakerUtils.getSpecialStack("minecraft:potion->minecraft:strong_regeneration")], 20, 400);
 
 //Add an extractor recipe that takes 4 coal -> 1 gunpowder
-TRTweaker.addExtractor(["minecraft:coal@4"], [TweakerUtils.createItemStack("minecraft:gunpowder", 1)], 10, 300);
+TRTweaker.addExtractor(["minecraft:coal@4"], ["minecraft:gunpowder"], 10, 300);
 
 //Add a grinder recipe of 1 sugar cane -> 3 sugar
-TRTweaker.addGrinder(["minecraft:sugar_cane"], [TweakerUtils.createItemStack("minecraft:sugar", 3)], 4, 270);
+TRTweaker.addGrinder(["minecraft:sugar_cane"], ["minecraft:sugar@3"], 4, 270);
 
 //Add an implosion compressor recipe of 32 coal and 16 flint -> 16 diamonds
-TRTweaker.addImplosionCompressor(["minecraft:coal@32", "minecraft:flint@16"], [TweakerUtils.createItemStack("minecraft:diamond", 16)], 30, 2000);
+TRTweaker.addImplosionCompressor(["minecraft:coal@32", "minecraft:flint@16"], ["minecraft:diamond@16"], 30, 2000);
 
 //Add an industrial electrolyzer recipe of 1 skeleton skull -> 1 wither skeleton skull
-TRTweaker.addIndustrialElectrolyzer(["minecraft:skeleton_skull"], [TweakerUtils.createItemStack("minecraft:wither_skeleton_skull", 1)], 50, 1400);
+TRTweaker.addIndustrialElectrolyzer(["minecraft:skeleton_skull"], ["minecraft:wither_skeleton_skull"], 50, 1400);
 
 //Add an industrial electrolyzer recipe of 1 sea lantern -> 5 prismarine crystals and 4 prismarine shards
-TRTweaker.addIndustrialGrinder(["minecraft:sea_lantern"], [TweakerUtils.createItemStack("minecraft:prismarine_crystals", 5), TweakerUtils.createItemStack("minecraft:prismarine_shard", 4)], 64, 100);
+TRTweaker.addIndustrialGrinder(["minecraft:sea_lantern"], ["minecraft:prismarine_crystals@5", "minecraft:prismarine_shard@4"], 64, 100);
 
 //Add an industrial electrolyzer recipe of 1 sea lantern and 1 bucket of electrolyzed water -> 9 prismarine crystals
-TRTweaker.addIndustrialGrinder(["minecraft:sea_lantern"], [TweakerUtils.createItemStack("minecraft:prismarine_crystals", 9)], 64, 100, "techreborn:electrolyzed_water@1000");
+TRTweaker.addIndustrialGrinder(["minecraft:sea_lantern"], ["minecraft:prismarine_crystals@9"], 64, 100, "techreborn:electrolyzed_water@1000");
 
 //Add an industrial sawmill recipe of 3 sugar cane -> 18 paper
-TRTweaker.addIndustrialSawmill(["minecraft:sugar_cane@3"], [TweakerUtils.createItemStack("minecraft:paper", 18)], 40, 200);
+TRTweaker.addIndustrialSawmill(["minecraft:sugar_cane@3"], ["minecraft:paper@18"], 40, 200);
 
 //Add an industrial sawmill recipe of 1 heart of the sea and 1/2 bucket of water -> 16 nautilus shells
-TRTweaker.addIndustrialSawmill(["minecraft:heart_of_the_sea"], [TweakerUtils.createItemStack("minecraft:nautilus_shell", 16)], 40, 200, "minecraft:water@500");
+TRTweaker.addIndustrialSawmill(["minecraft:heart_of_the_sea"], ["minecraft:nautilus_shell@16"], 40, 200, "minecraft:water@500");
 
 //Add a recycler recipe of 1 water bucket -> 1 empty bucket
-TRTweaker.addRecycler(["minecraft:water_bucket"], [TweakerUtils.createItemStack("minecraft:bucket", 1)], 5, 40);
+TRTweaker.addRecycler(["minecraft:water_bucket"], ["minecraft:bucket"], 5, 40);
 
 //Add a scrapbox recipe of 1 scrap box -> 1 shulker box
-TRTweaker.addScrapbox(TweakerUtils.createItemStack("minecraft:shulker_box", 1), 10, 20);
+TRTweaker.addScrapbox("minecraft:shulker_box", 10, 20);
 
 //Add a scrapbox recipe of 1 cell of water -> 1 blue ice
-TRTweaker.addVacuumFreezer([TRTweaker.createFluidIngredient("minecraft:water", ["techreborn:cell"], -1)], [TweakerUtils.createItemStack("minecraft:blue_ice", 1)], 60, 440);
+TRTweaker.addVacuumFreezer([TRTweaker.createFluidIngredient("minecraft:water", ["techreborn:cell"], -1)], ["minecraft:blue_ice"], 60, 440);
 
 //Add a fluid replicator recipe of 2 uu matter and 1 bucket of wulframium -> 2 buckets of wolframium
 TRTweaker.addFluidReplicator(["techreborn:uu_matter@2"], 40, 100, "techreborn:wolframium@1000");
 
 //Add a fusion reactor recipe of 3 wither skeleton skulls and 4 soul sand -> 1 nether star
-TRTweaker.addFusionReactor(["minecraft:wither_skeleton_skull@3", "minecraft:soul_sand@4"], [TweakerUtils.createItemStack("minecraft:nether_star", 1)], -2048, 1024, 90000, 1);
+TRTweaker.addFusionReactor(["minecraft:wither_skeleton_skull@3", "minecraft:soul_sand@4"], ["minecraft:nether_star"], -2048, 1024, 90000, 1);
 
 //Add a rolling machine recipe for 5 popped chorus fruit in a helmet shape -> a shulker shell
 var chorus = "minecraft:popped_chorus_fruit";
-TRTweaker.addRollingMachine([[chorus, chorus, chorus], [chorus, "", chorus]], TweakerUtils.createItemStack("minecraft:shulker_shell", 1));
+TRTweaker.addRollingMachine([[chorus, chorus, chorus], [chorus, "", chorus]], "minecraft:shulker_shell");
 
 //Create a pattern/dictionary set for a shaped recipe
 var pattern = [ '/ /',
@@ -77,13 +80,13 @@ var dict = {
 };
 
 //Add a rolling machine recipe for sticks on the sides and any wooden slab in the middle -> six ladders
-TRTweaker.addRollingMachine(pattern, dict, TweakerUtils.createItemStack("minecraft:ladder", 12));
+TRTweaker.addDictRollingMachine(pattern, dict, "minecraft:ladder@12");
 
 //Add a solid canning machine recipe for 1 empty cell and 1 blue ice -> a cell full of water
 TRTweaker.addSolidCanningMachine(["techreborn:cell{}", "minecraft:blue_ice"], [TweakerUtils.getSpecialStack("techreborn:cell->minecraft:water")], 1, 100);
 
 //Add a wire mill recipe for 1 woll -> 4 string
-TRTweaker.addWireMill(["#minecraft:wool"], [TweakerUtils.createItemStack("minecraft:string", 4)], 2, 200);
+TRTweaker.addWireMill(["#minecraft:wool"], ["minecraft:string@4"], 2, 200);
 
 //Add a plasma fluid generator recipe for 1 mB of wolframium -> 300 EU
 TRTweaker.addFluidGenerator("plasma", "techreborn:wolframium", 300);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,6 +24,9 @@
     ],
     "towelette": [
       "techreborn.compat.towelette.TowelettePlugin"
+    ],
+    "libcd": [
+      "techreborn.compat.libcd.LibCDPlugin"
     ]
   },
   "depends": {


### PR DESCRIPTION
Updates the LibCD compat to LibCD 2.0. Main changes:
- uses the new LibCD entrypoint for registration, meaning no `FabricLoader.getInstance().isModLoaded()` check in the main entrypoint
- recipe-add methods now take an `Object[]` for outputs instead of an `ItemStack[]`
  - due to this change, the `TRTweaker.addRollingMachine(String[], Map<String, Object>, ItemStack)` method has been renamed to `TRTweaker.addDictRollingMachine(String[], Map<String, Object>, ItemStack)` to prevent Nashorn method overload. This is a breaking change that cannot be put through deprecation.
- the ancient bug causing `TRTweaker.addRollingMachine(Object[], Object, int, int)` to throw `IndexOutOfBoundsException`s has been fixed
- running `/libcd debug export` now adds info about fluid generator recipes 
- `TRTweaker` now uses a LibCD logger instead of a TechReborn one, so that the namespace of the script registering recipes can be displayed
- the tweaker sample script has been updated for all new changes

Known issues:
- due to RebornCore not registering `RebornRecipeType`s in `Registry.RECIPE_TYPE`, any RebornRecipe added will show up as the `unknown` recipe type in RecipeTweaker's debug export. I am not willing to add special behavior for RebornRecipes.
- the LibCD API, while now fully self-contained, does not currently have a JiJ-able form. This will be remedied when I have the time.