### PR TITLE
Temporary fix for REI fluid cells integration

### DIFF
--- a/src/main/java/techreborn/compat/rei/MachineRecipeDisplay.java
+++ b/src/main/java/techreborn/compat/rei/MachineRecipeDisplay.java
@@ -58,6 +58,11 @@ public class MachineRecipeDisplay<R extends RebornRecipe> implements RecipeDispl
 			this.fluidInstance = ((RebornFluidRecipe) recipe).getFluidInstance();
 			inputs.add(Collections.singletonList(EntryStack.create(fluidInstance.getFluid(), fluidInstance.getAmount().getRawValue())));
 		}
+		for (List<EntryStack> entries : inputs)
+			for (EntryStack stack : entries)
+				ReiPlugin.applyCellEntry(stack);
+		for (EntryStack stack : outputs)
+			ReiPlugin.applyCellEntry(stack);
 	}
 	
 	public int getEnergy() {

--- a/src/main/java/techreborn/compat/rei/ReiPlugin.java
+++ b/src/main/java/techreborn/compat/rei/ReiPlugin.java
@@ -171,18 +171,9 @@ public class ReiPlugin implements REIPluginV0 {
 		// Check Tags will not check the amount of the ItemStack, but will enable checking their tags.
 		for (EntryStack stack : RoughlyEnoughItemsCore.getEntryRegistry().getStacksList())
 			applyCellEntry(stack);
-		for (List<RecipeDisplay> displays : RecipeHelper.getInstance().getAllRecipes().values()) {
-			for (RecipeDisplay display : displays) {
-				for (List<EntryStack> entries : display.getInputEntries())
-					for (EntryStack stack : entries)
-						applyCellEntry(stack);
-				for (EntryStack stack : display.getOutputEntries())
-					applyCellEntry(stack);
-			}
-		}
 	}
 	
-	private void applyCellEntry(EntryStack stack) {
+	public static void applyCellEntry(EntryStack stack) {
 		// getItem can be null but this works
 		if (stack.getItem() == TRContent.CELL)
 			stack.addSetting(EntryStack.Settings.CHECK_TAGS, EntryStack.Settings.TRUE);


### PR DESCRIPTION
Since current solutions isn't working, this will fix recipe entries only for TR machines.
The reason it isn't working now is because postRegister() called **before** all other recipes added (including TR recipes)