### PR TITLE
Slightly better REI fluid handling

### DIFF
--- a/src/main/java/techreborn/compat/rei/MachineRecipeDisplay.java
+++ b/src/main/java/techreborn/compat/rei/MachineRecipeDisplay.java
@@ -48,15 +48,15 @@ public class MachineRecipeDisplay<R extends RebornRecipe> implements RecipeDispl
 	
 	public MachineRecipeDisplay(R recipe) {
 		this.recipe = recipe;
-		this.inputs = CollectionUtils.map(recipe.getRebornIngredients(), ing -> CollectionUtils.map(ing.getPreviewStacks(), EntryStack::create));
-		this.outputs = CollectionUtils.map(recipe.getOutputs(), EntryStack::create);
+		this.inputs = CollectionUtils.map(recipe.getRebornIngredients(), ing -> CollectionUtils.map(ing.getPreviewStacks(), RebornEntryStack::create));
+		this.outputs = CollectionUtils.map(recipe.getOutputs(), RebornEntryStack::create);
 		this.energy = recipe.getPower();
 		if (recipe instanceof BlastFurnaceRecipe) {
 			this.heat = ((BlastFurnaceRecipe) recipe).getHeat();
 		}
 		if (recipe instanceof RebornFluidRecipe) {
 			this.fluidInstance = ((RebornFluidRecipe) recipe).getFluidInstance();
-			inputs.add(Collections.singletonList(EntryStack.create(fluidInstance.getFluid(), fluidInstance.getAmount().getRawValue())));
+			inputs.add(Collections.singletonList(RebornEntryStack.create(fluidInstance.getFluid(), fluidInstance.getAmount().getRawValue())));
 		}
 		for (List<EntryStack> entries : inputs)
 			for (EntryStack stack : entries)

--- a/src/main/java/techreborn/compat/rei/RebornEntryStack.java
+++ b/src/main/java/techreborn/compat/rei/RebornEntryStack.java
@@ -1,0 +1,45 @@
+package techreborn.compat.rei;
+
+import me.shedaniel.rei.api.EntryStack;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.item.ItemStack;
+import reborncore.common.fluid.container.ItemFluidInfo;
+import techreborn.utils.FluidUtils;
+
+public interface RebornEntryStack extends EntryStack {
+
+	static EntryStack create(Fluid fluid, int amount) {
+		return new RebornFluidEntryStack(fluid, amount);
+	}
+
+	static EntryStack create(ItemStack stack) {
+		return new RebornItemEntryStack(stack);
+	}
+
+	static boolean compareFluids(EntryStack a, Object obj) {
+		if (!(obj instanceof EntryStack)) {
+			return false;
+		}
+
+		Fluid fluid1, fluid2;
+		if (a.getItem() instanceof ItemFluidInfo) {
+			fluid1 = ((ItemFluidInfo) a.getItem()).getFluid(a.getItemStack());
+		} else {
+			fluid1 = a.getFluid();
+		}
+
+		EntryStack b = (EntryStack) obj;
+		if (b.getItem() instanceof ItemFluidInfo) {
+			fluid2 = ((ItemFluidInfo) b.getItem()).getFluid(b.getItemStack());
+		} else {
+			fluid2 = b.getFluid();
+		}
+
+		if (fluid1 != null && fluid2 != null) {
+			return FluidUtils.fluidEquals(fluid1, fluid2);
+		}
+
+		return false;
+	}
+
+}

--- a/src/main/java/techreborn/compat/rei/RebornFluidEntryStack.java
+++ b/src/main/java/techreborn/compat/rei/RebornFluidEntryStack.java
@@ -1,0 +1,20 @@
+package techreborn.compat.rei;
+
+import me.shedaniel.rei.impl.FluidEntryStack;
+import net.minecraft.fluid.Fluid;
+
+public class RebornFluidEntryStack extends FluidEntryStack {
+
+	public RebornFluidEntryStack(Fluid fluid, int amount) {
+		super(fluid, amount);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (super.equals(obj)) {
+			return true;
+		}
+		return RebornEntryStack.compareFluids(this, obj);
+	}
+
+}

--- a/src/main/java/techreborn/compat/rei/RebornItemEntryStack.java
+++ b/src/main/java/techreborn/compat/rei/RebornItemEntryStack.java
@@ -1,0 +1,20 @@
+package techreborn.compat.rei;
+
+import me.shedaniel.rei.impl.ItemEntryStack;
+import net.minecraft.item.ItemStack;
+
+public class RebornItemEntryStack extends ItemEntryStack {
+
+	public RebornItemEntryStack(ItemStack itemStack) {
+		super(itemStack);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (super.equals(obj)) {
+			return true;
+		}
+		return RebornEntryStack.compareFluids(this, obj);
+	}
+
+}

--- a/src/main/java/techreborn/compat/rei/fluidgenerator/FluidGeneratorRecipeDisplay.java
+++ b/src/main/java/techreborn/compat/rei/fluidgenerator/FluidGeneratorRecipeDisplay.java
@@ -29,6 +29,7 @@ import me.shedaniel.rei.api.EntryStack;
 import me.shedaniel.rei.api.RecipeDisplay;
 import net.minecraft.util.Identifier;
 import techreborn.api.generator.FluidGeneratorRecipe;
+import techreborn.compat.rei.RebornEntryStack;
 
 import java.util.Collections;
 import java.util.List;
@@ -43,7 +44,7 @@ public class FluidGeneratorRecipeDisplay implements RecipeDisplay {
 		this.category = category;
 		this.inputs = Lists.newArrayList();
 		this.totalEnergy = recipe.getEnergyPerBucket();
-		inputs.add(Collections.singletonList(EntryStack.create(recipe.getFluid(), 1000)));
+		inputs.add(Collections.singletonList(RebornEntryStack.create(recipe.getFluid(), 1000)));
 	}
 	
 	@Override

--- a/src/main/java/techreborn/compat/rei/fluidreplicator/FluidReplicatorRecipeDisplay.java
+++ b/src/main/java/techreborn/compat/rei/fluidreplicator/FluidReplicatorRecipeDisplay.java
@@ -30,6 +30,7 @@ import me.shedaniel.rei.utils.CollectionUtils;
 import net.minecraft.util.Identifier;
 import reborncore.common.fluid.container.FluidInstance;
 import techreborn.api.recipe.recipes.FluidReplicatorRecipe;
+import techreborn.compat.rei.RebornEntryStack;
 
 import java.util.Collections;
 import java.util.List;
@@ -47,9 +48,9 @@ public class FluidReplicatorRecipeDisplay implements RecipeDisplay {
 	
 	public FluidReplicatorRecipeDisplay(FluidReplicatorRecipe recipe) {
 		this.recipe = recipe;
-		this.inputs = CollectionUtils.map(recipe.getRebornIngredients(), ing -> CollectionUtils.map(ing.getPreviewStacks(), EntryStack::create));
+		this.inputs = CollectionUtils.map(recipe.getRebornIngredients(), ing -> CollectionUtils.map(ing.getPreviewStacks(), RebornEntryStack::create));
 		this.fluidInstance = recipe.getFluidInstance();
-		this.output = fluidInstance == null ? Collections.emptyList() : Collections.singletonList(EntryStack.create(fluidInstance.getFluid(), fluidInstance.getAmount().getRawValue()));
+		this.output = fluidInstance == null ? Collections.emptyList() : Collections.singletonList(RebornEntryStack.create(fluidInstance.getFluid(), fluidInstance.getAmount().getRawValue()));
 		this.energy = recipe.getPower();
 	}
 	


### PR DESCRIPTION
Now you can jump between fluid/cells/buckets when looking for recipes.
Unfortunately this isn't working for items in side panel, only when jumping between crafting displays :(