### PR TITLE
Add quartz dust recipe to grinder

### DIFF
--- a/src/main/resources/data/techreborn/recipes/grinder/quartz_dust.json
+++ b/src/main/resources/data/techreborn/recipes/grinder/quartz_dust.json
@@ -1,0 +1,15 @@
+{
+  "type": "techreborn:grinder",
+  "power": 4,
+  "time": 270,
+  "ingredients": [
+    {
+      "item": "minecraft:quartz"
+    }
+  ],
+  "results": [
+    {
+      "item": "techreborn:quartz_dust"
+    }
+  ]
+}


### PR DESCRIPTION
The quartz dust added in 162e4bb doesn't currently have a recipe for the grinder, and can't be obtained. This PR simply adds a recipe for it copying the values from the quartz ore.