### PR TITLE
Fix golden apple chemical reactor recipe

### DIFF
--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/golden_apple.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/golden_apple.json
@@ -4,8 +4,8 @@
 	"time": 400,
 	"ingredients": [
 		{
-			"item": "minecraft:gold_nugget",
-			"count": 8
+			"item": "minecraft:gold_ingot",
+			"count": 6
 		},
 		{
 			"item": "minecraft:apple"


### PR DESCRIPTION
As of 3.3.3, a golden apple can be created using 8 gold nuggets and an apple in the chemical reactor. That golden apple can then be put in the the industrial centrifuge to receive 6 gold ingots, making it an easy way to get large amounts of gold if you have a lot of apples lying around.

I assume the reactor recipe is a legacy of Minecraft 1.1 where golden apples were crafted with 8 gold nuggets.

This PR resolves the issue by requiring 6 gold ingots in the chemical reactor recipe, which both prevents abuse while remaining 25% more efficient than standard crafting.

Alternatively, the recipe could be simply removed to reduce complexity.