### PR TITLE
Add (vanilla) blasting recipes for ores/dusts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,7 @@ jar {
 
 	from { crowdin.getDidWork() ? fileTree('build/translations').matching{exclude "**/en_US.json"} : null}
 	dependsOn 'fixTranslations'
+	dependsOn 'compileRecipes'
 }
 
 
@@ -245,4 +246,36 @@ task curseTools {
 			arg(value: remapJar.archivePath.getAbsolutePath())
 		}
 	}
+}
+
+// Generate recipe JSON for similar recipes
+import java.util.regex.Pattern
+
+task compileRecipes {
+    def jsonSlurper = new JsonSlurper()
+	def recipePath = "build/resources/main/data/techreborn/recipes"
+
+	def smeltingPath = recipePath + "/smelting"
+	def blastingPath = recipePath + "/blasting"
+
+    doLast {
+		// Add any recipe filenames that don't match the regex here
+		String[] whitelist = []
+		def pattern = ~'^\\w+_(ingot(_from_dust)?)\\.json$'
+
+		file(smeltingPath).eachFileRecurse(groovy.io.FileType.FILES) {
+			if (whitelist.contains(it.name) || it.name ==~ pattern) {
+				def recipe = jsonSlurper.parseText(it.text)
+
+				// Final failsafe
+				if (["smelting", "minecraft:smelting"].contains(recipe.type)) {
+					recipe.type = "minecraft:blasting"
+					recipe.cookingtime = recipe.cookingtime / 2
+
+					File output = new File(blastingPath, it.name)
+					output.write(JsonOutput.prettyPrint(JsonOutput.toJson(recipe)))
+				}
+			}
+		}
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -252,7 +252,7 @@ task curseTools {
 import java.util.regex.Pattern
 
 task compileRecipes {
-    def jsonSlurper = new JsonSlurper()
+	def jsonSlurper = new JsonSlurper()
 	def recipePath = "build/resources/main/data/techreborn/recipes"
 
 	def smeltingPath = recipePath + "/smelting"

--- a/src/main/resources/data/techreborn/recipes/blasting/readme.txt
+++ b/src/main/resources/data/techreborn/recipes/blasting/readme.txt
@@ -1,0 +1,5 @@
+This directory is for vanilla Minecraft's blast furnace, not the blast furnace added by TechReborn.
+
+!! DO NOT add recipes here unless they do not have a counterpart smelting recipe. !!
+
+All of TechReborn's smelting recipes are automatically added to the (vanilla) blast furnace at build time using the "compileRecipes" Gradle task.


### PR DESCRIPTION
Implements #2037 using a Gradle task to automatically generate the recipe json at build time.

It halves the `cookingtime` for each recipe.