### PR TITLE
Blockus compatibility (1.15+)

### DIFF
--- a/src/main/resources/data/techreborn/recipes/centrifuge/marble_dust.json
+++ b/src/main/resources/data/techreborn/recipes/centrifuge/marble_dust.json
@@ -4,7 +4,8 @@
   "time": 2050,
   "ingredients": [
     {
-      "item": "techreborn:marble_dust"
+      "item": "techreborn:marble_dust",
+      "count": 8
     }
   ],
   "results": [

--- a/src/main/resources/data/techreborn/recipes/crafting_table/unit/storage/crude_storage_unit_blockus.json
+++ b/src/main/resources/data/techreborn/recipes/crafting_table/unit/storage/crude_storage_unit_blockus.json
@@ -1,0 +1,29 @@
+{
+  "type": "minecraft:crafting_shaped",
+
+  "pattern": [
+    "WWW",
+    "WBW",
+    "WPW"
+  ],
+
+  "key": {
+    "B": {
+      "tag": "blockus:barrels"
+    },
+	"P": {
+      "item": "minecraft:paper"
+    },
+	"W": {
+      "tag": "minecraft:planks"
+    }
+  },
+
+  "result": {
+    "item": "techreborn:crude_storage_unit"
+  },
+
+  "conditions": {
+    "reborncore:tag": "blockus:barrels"
+  }
+}

--- a/src/main/resources/data/techreborn/recipes/grinder/marble_dust_from_limestone.json
+++ b/src/main/resources/data/techreborn/recipes/grinder/marble_dust_from_limestone.json
@@ -1,0 +1,21 @@
+{
+  "type": "techreborn:grinder",
+  "power": 2,
+  "time": 180,
+
+  "ingredients" : [
+    {
+      "tag": "c:limestone"
+    }
+  ],
+
+  "results" : [
+    {
+      "item": "techreborn:marble_dust"
+    }
+  ],
+
+  "conditions": {
+    "reborncore:tag": "c:limestone"
+  }
+}

--- a/src/main/resources/data/techreborn/recipes/grinder/marble_dust_from_marble.json
+++ b/src/main/resources/data/techreborn/recipes/grinder/marble_dust_from_marble.json
@@ -1,0 +1,21 @@
+{
+  "type": "techreborn:grinder",
+  "power": 2,
+  "time": 180,
+
+  "ingredients" : [
+    {
+      "tag": "c:marble"
+    }
+  ],
+
+  "results" : [
+    {
+      "item": "techreborn:marble_dust"
+    }
+  ],
+
+  "conditions": {
+    "reborncore:tag": "c:marble"
+  }
+}


### PR DESCRIPTION
Building on the datapack published by @justastranger in #2046, this allows to grind basalt/marble/limestone and craft crude storage units from the different wood barrels added by blockus.

I only added the compat related changes from @justastranger because I didn't feel comfortable comitting all of them under my name.

The "vanilla" crude storage recipe should probably be hidden as well if blockus is installed as it completely replaces the plain barrels.

This is unfortunately not compile tested as I don't have a dev environment, but the recipes have all been tested via the datapack.

Edit: Removed terrestria changes