### PR TITLE
Allow grinding of vanilla basalt blocks

### DIFF
--- a/src/main/resources/data/c/tags/blocks/basalt.json
+++ b/src/main/resources/data/c/tags/blocks/basalt.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:basalt",
+    "minecraft:polished_basalt"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/basalt.json
+++ b/src/main/resources/data/c/tags/items/basalt.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:basalt",
+    "minecraft:polished_basalt"
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/grinder/basalt_dust_from_basalt.json
+++ b/src/main/resources/data/techreborn/recipes/grinder/basalt_dust_from_basalt.json
@@ -1,0 +1,17 @@
+{
+  "type": "techreborn:grinder",
+  "power": 2,
+  "time": 180,
+
+  "ingredients" : [
+    {
+      "tag": "c:basalt"
+    }
+  ],
+
+  "results" : [
+    {
+      "item": "techreborn:basalt_dust"
+    }
+  ]
+}


### PR DESCRIPTION
If Terrestria decides its volcanic rocks also count as basalt, they will be automatically recognized by the recipe thanks to tagging. Doing it this way means 1.15 unfortunately won't get basalt dust out of the box, but it's too much of a headache (and it can always be done manually via datapack).

Related to #2091, #2046, https://github.com/TerraformersMC/Terrestria/pull/117