### PR TITLE
[WIP] Change electric cables to use networks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ repositories {
 	}
 }
 
-version = "3.3.11"
+version = "3.4.0"
 
 configurations {
 	shade

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ repositories {
 	}
 }
 
-version = "3.4.0"
+version = "3.3.11"
 
 configurations {
 	shade

--- a/src/main/java/techreborn/TechReborn.java
+++ b/src/main/java/techreborn/TechReborn.java
@@ -54,6 +54,7 @@ import techreborn.blockentity.storage.energy.idsu.IDSUManager;
 import techreborn.client.GuiType;
 import techreborn.compat.trinkets.Trinkets;
 import techreborn.config.TechRebornConfig;
+import techreborn.enet.ElectricNetworkManager;
 import techreborn.events.ModRegistry;
 import techreborn.init.FluidGeneratorRecipes;
 import techreborn.init.ModLoot;
@@ -106,6 +107,7 @@ public class TechReborn implements ModInitializer {
 		GuiType.AESU.getIdentifier();
 		TRDispenserBehavior.init();
 		PoweredCraftingHandler.setup();
+		ElectricNetworkManager.init();
 
 		Torus.genSizeMap(TechRebornConfig.fusionControlComputerMaxCoilSize);
 

--- a/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
@@ -167,7 +167,7 @@ public class CableBlockEntity extends BlockEntity
 
 		if (electricNetwork == null) {
 			TechReborn.LOGGER.debug("Block Entity has no network in tick() -- assigning a network");
-			this.AssignNetwork();
+			this.assignNetwork();
 		}
 	}
 
@@ -206,7 +206,7 @@ public class CableBlockEntity extends BlockEntity
 		return other != null && other.getCableType().tier == getCableType().tier;
 	}
 
-	public ArrayList<PowerAcceptorBlockEntityFace> getConnectedPowerAcceptors() {
+	public List<PowerAcceptorBlockEntityFace> getConnectedPowerAcceptors() {
 		ArrayList<PowerAcceptorBlockEntityFace> result = new ArrayList<>();
 
 		for (Direction face : Direction.values()) {
@@ -220,7 +220,7 @@ public class CableBlockEntity extends BlockEntity
 		return result;
 	}
 
-	private void AssignNetwork() {
+	private void assignNetwork() {
 		if (!hasWorld()) {
 			TechReborn.LOGGER.debug("Attempting to assign an electric network for cable block entity but no World is available");
 			return;

--- a/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
@@ -35,9 +35,9 @@ import net.minecraft.nbt.NbtHelper;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import net.minecraft.util.Pair;
 import net.minecraft.util.Tickable;
 import net.minecraft.util.math.Direction;
-import org.apache.commons.lang3.tuple.Pair;
 import reborncore.api.IListInfoProvider;
 import reborncore.api.IToolDrop;
 import reborncore.common.network.ClientBoundPackets;
@@ -45,28 +45,25 @@ import reborncore.common.network.NetworkManager;
 import reborncore.common.powerSystem.PowerAcceptorBlockEntity;
 import reborncore.common.powerSystem.PowerSystem;
 import reborncore.common.util.StringUtils;
-import team.reborn.energy.Energy;
-import team.reborn.energy.EnergySide;
-import team.reborn.energy.EnergyStorage;
-import team.reborn.energy.EnergyTier;
+import team.reborn.energy.*;
+import techreborn.TechReborn;
 import techreborn.blocks.cable.CableBlock;
+import techreborn.enet.ElectricNetworkManager;
 import techreborn.init.TRBlockEntities;
 import techreborn.init.TRContent;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
- * Created by modmuss50 on 19/05/2017.
+ * Created by wgraham17 on 28/05/2020.
  */
 
 public class CableBlockEntity extends BlockEntity
-	implements Tickable, IListInfoProvider, IToolDrop, EnergyStorage {
-	
-	private double energy = 0;
+		implements Tickable, IListInfoProvider, IToolDrop {
+
+	private int electric_net_id = 0;
 	private TRContent.Cables cableType = null;
-	private ArrayList<Direction> sendingFace = new ArrayList<>();
 	private BlockState cover = null;
 
 	public CableBlockEntity() {
@@ -78,7 +75,7 @@ public class CableBlockEntity extends BlockEntity
 		this.cableType = type;
 	}
 
-	private TRContent.Cables getCableType() {
+	public TRContent.Cables getCableType() {
 		if (cableType != null) {
 			return cableType;
 		}
@@ -86,32 +83,64 @@ public class CableBlockEntity extends BlockEntity
 			return TRContent.Cables.COPPER;
 		}
 		Block block = world.getBlockState(pos).getBlock();
-		if(block instanceof CableBlock){
+		if (block instanceof CableBlock) {
 			return ((CableBlock) block).type;
 		}
 		//Something has gone wrong if this happens
 		return TRContent.Cables.COPPER;
 	}
 
-	@Override
-    public CompoundTag toInitialChunkDataTag() {
-        return toTag(new CompoundTag());
-    }
+	public int getElectricNetworkId() {
+		return electric_net_id;
+	}
 
-    @Override
-    public BlockEntityUpdateS2CPacket toUpdatePacket() {
-        CompoundTag nbtTag = new CompoundTag();
-        toTag(nbtTag);
-        return new BlockEntityUpdateS2CPacket(getPos(), 1, nbtTag);
-    }
-
-
-    @Override
-    public void fromTag(CompoundTag compound) {
-		super.fromTag(compound);
-		if (compound.contains("energy")) {
-			energy = compound.getDouble("energy");
+	public boolean isEnergized() {
+		if (electric_net_id == 0) {
+			return false;
 		}
+
+		return ElectricNetworkManager.INSTANCE.getNetwork(electric_net_id, getCableType().tier).isEnergized();
+	}
+
+	public void setElectricNetwork(int value)
+	{
+		if (electric_net_id != 0) {
+			ElectricNetworkManager.INSTANCE.getNetwork(electric_net_id, getCableType().tier).removeBlockEntity(this);
+		}
+
+		if (value != 0) {
+			ElectricNetworkManager.INSTANCE.getNetwork(value, getCableType().tier).addBlockEntity(this);
+		}
+
+		electric_net_id = value;
+	}
+
+	@Override
+	public void markRemoved() {
+		if (electric_net_id != 0) {
+			TechReborn.LOGGER.debug("Removing block {} from ENet {}", this.getPos().asLong(), electric_net_id);
+			ElectricNetworkManager.INSTANCE.getNetwork(electric_net_id, getCableType().tier).removeBlockEntity(this);
+		}
+
+		super.markRemoved();
+	}
+
+	@Override
+	public CompoundTag toInitialChunkDataTag() {
+		return toTag(new CompoundTag());
+	}
+
+	@Override
+	public BlockEntityUpdateS2CPacket toUpdatePacket() {
+		CompoundTag nbtTag = new CompoundTag();
+		toTag(nbtTag);
+		return new BlockEntityUpdateS2CPacket(getPos(), 1, nbtTag);
+	}
+
+	@Override
+	public void fromTag(CompoundTag compound) {
+		super.fromTag(compound);
+
 		if (compound.contains("cover")) {
 			cover = NbtHelper.toBlockState(compound.getCompound("cover"));
 		} else {
@@ -119,10 +148,10 @@ public class CableBlockEntity extends BlockEntity
 		}
 	}
 
-    @Override
-    public CompoundTag toTag(CompoundTag compound) {
+	@Override
+	public CompoundTag toTag(CompoundTag compound) {
 		super.toTag(compound);
-		compound.putDouble("energy", energy);
+
 		if (cover != null) {
 			compound.put("cover", NbtHelper.fromBlockState(cover));
 		}
@@ -131,46 +160,17 @@ public class CableBlockEntity extends BlockEntity
 
 	@Override
 	public void tick() {
-		if (world.isClient) {
+		if (world == null || world.isClient) {
 			return;
 		}
 
-		sendingFace.clear();
-
-		if(getEnergy() == 0){
-			return;
+		if (this.electric_net_id == 0) {
+			TechReborn.LOGGER.debug("Block Entity has no network in tick() -- assigning a network");
+			this.AssignNetwork();
 		}
-
-		ArrayList<Pair<BlockEntity, Direction>> acceptors = new ArrayList<>();
-		for (Direction face : Direction.values()) {
-			BlockEntity blockEntity = world.getBlockEntity(pos.offset(face));
-
-			if (blockEntity != null && Energy.valid(blockEntity)) {
-				if (blockEntity instanceof CableBlockEntity && energy <= Energy.of(blockEntity).side(face).getEnergy()) {
-					continue;
-				}
-				if(Energy.of(blockEntity).side(face.getOpposite()).getMaxInput() > 0){
-					acceptors.add(Pair.of(blockEntity, face));
-					if (!sendingFace.contains(face)) {
-						sendingFace.add(face);
-					}
-				}
-			}
-		}
-
-		if (acceptors.isEmpty()) {
-			return;
-		}
-		Collections.shuffle(acceptors);
-
-        acceptors.forEach(pair -> {
-	        Energy.of(this)
-		        .into(Energy.of(pair.getLeft()).side(pair.getRight().getOpposite()))
-		        .move();
-        });
 	}
 
-    // IListInfoProvider
+	// IListInfoProvider
 	@Override
 	public void addInfo(List<Text> info, boolean isReal, boolean hasData) {
 		info.add(new LiteralText(Formatting.GRAY + StringUtils.t("techreborn.tooltip.transferRate") + ": "
@@ -189,74 +189,61 @@ public class CableBlockEntity extends BlockEntity
 		return new ItemStack(getCableType().block);
 	}
 
-
-	public double getEnergy() {
-		return getStored(EnergySide.UNKNOWN);
-	}
-
-	public void setEnergy(double energy) {
-		setStored(energy);
-	}
-
-	public double useEnergy(double energyOut, boolean simulate) {
-		if (energyOut > energy) {
-			energyOut = energy;
-		}
-		if (!simulate) {
-			setEnergy(energy - energyOut);
-		}
-		return energyOut;
-	}
-
-	public boolean canAcceptEnergy(EnergySide direction) {
-		if (sendingFace.contains(direction)) {
-			return false;
-		}
-		return getMaxStoredPower() != getEnergy();
-	}
-
-	@Override
-	public double getMaxInput(EnergySide side) {
-		if(!canAcceptEnergy(side)) {
-			return 0;
-		}
-		return getCableType().transferRate;
-	}
-
-	@Override
-	public double getMaxOutput(EnergySide side) {
-		return getCableType().transferRate;
-	}
-
-	@Override
-	public double getMaxStoredPower() {
-		return getCableType().transferRate * 4;
-	}
-
-	@Override
-	public EnergyTier getTier() {
-		return PowerAcceptorBlockEntity.getTier(getCableType().transferRate);
-	}
-
-	@Override
-	public double getStored(EnergySide face) {
-		return energy;
-	}
-
-	@Override
-	public void setStored(double amount) {
-		this.energy = amount;
-	}
-
 	public BlockState getCover() {
 		return cover;
 	}
 
 	public void setCover(BlockState cover) {
 		this.cover = cover;
-		if (!world.isClient) {
+
+		if (world != null && !world.isClient) {
 			NetworkManager.sendToTracking(ClientBoundPackets.createCustomDescriptionPacket(this), this);
 		}
+	}
+
+	public boolean canConnectTo(CableBlockEntity other) {
+		return other != null && other.getCableType().tier == getCableType().tier;
+	}
+
+	public ArrayList<Pair<PowerAcceptorBlockEntity, Direction>> getConnectedPowerAcceptors() {
+		ArrayList<Pair<PowerAcceptorBlockEntity, Direction>> result = new ArrayList<>();
+
+		for (Direction face : Direction.values()) {
+			BlockEntity blockEntity = world.getBlockEntity(pos.offset(face));
+
+			if (blockEntity != null && Energy.valid(blockEntity) && blockEntity instanceof PowerAcceptorBlockEntity) {
+				result.add(new Pair<>((PowerAcceptorBlockEntity) blockEntity, face.getOpposite()));
+			}
+		}
+
+		return result;
+	}
+
+	private void AssignNetwork() {
+		if (!hasWorld()) {
+			TechReborn.LOGGER.debug("Attempting to assign an electric network for cable block entity but no World is available");
+			return;
+		}
+
+		int electric_net_to_join = 0;
+
+		for (Direction face : Direction.values()) {
+			BlockEntity blockEntity = world.getBlockEntity(pos.offset(face));
+
+			if (blockEntity instanceof CableBlockEntity && this.canConnectTo((CableBlockEntity) blockEntity)) {
+				electric_net_to_join = ((CableBlockEntity) blockEntity).getElectricNetworkId();
+				break;
+			}
+		}
+
+		if (electric_net_to_join == 0) {
+			TechReborn.LOGGER.debug("Could not find network to join, creating new one");
+			electric_net_to_join = ElectricNetworkManager.INSTANCE.newNetwork(getWorld(), getCableType().tier).getId();
+		} else {
+			TechReborn.LOGGER.debug("Successfully found another network to join: {}", electric_net_to_join);
+		}
+
+		this.setElectricNetwork(electric_net_to_join);
 	}
 
 }

--- a/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
@@ -35,7 +35,6 @@ import net.minecraft.nbt.NbtHelper;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-import net.minecraft.util.Pair;
 import net.minecraft.util.Tickable;
 import net.minecraft.util.math.Direction;
 import reborncore.api.IListInfoProvider;
@@ -45,7 +44,7 @@ import reborncore.common.network.NetworkManager;
 import reborncore.common.powerSystem.PowerAcceptorBlockEntity;
 import reborncore.common.powerSystem.PowerSystem;
 import reborncore.common.util.StringUtils;
-import team.reborn.energy.*;
+import team.reborn.energy.Energy;
 import techreborn.TechReborn;
 import techreborn.blocks.cable.CableBlock;
 import techreborn.enet.ElectricNetwork;
@@ -58,7 +57,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Created by wgraham17 on 28/05/2020.
+ * Created by modmuss50 on 19/05/2017.
  */
 
 public class CableBlockEntity extends BlockEntity

--- a/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
@@ -111,7 +111,8 @@ public class CableBlockEntity extends BlockEntity
 		}
 
 		if (value != null) {
-			value.addBlockEntity(this);
+			electricNetwork = value;
+			electricNetwork.addBlockEntity(this);
 		}
 	}
 

--- a/src/main/java/techreborn/blocks/cable/CableBlock.java
+++ b/src/main/java/techreborn/blocks/cable/CableBlock.java
@@ -136,6 +136,10 @@ public class CableBlock extends BlockWithEntity implements Waterloggable {
 	private Boolean canConnectTo(IWorld world, BlockPos pos, Direction facing) {
 		BlockEntity blockEntity = world.getBlockEntity(pos);
 		if (blockEntity != null && (Energy.valid(blockEntity) || blockEntity instanceof CableBlockEntity)) {
+			if (blockEntity instanceof CableBlockEntity && ((CableBlockEntity)blockEntity).getCableType().tier != type.tier) {
+				return Boolean.FALSE;
+			}
+
 			return Boolean.TRUE;
 		}
 		return Boolean.FALSE;
@@ -237,11 +241,10 @@ public class CableBlock extends BlockWithEntity implements Waterloggable {
 			return;
 		}
 
-		CableBlockEntity blockEntityCable = (CableBlockEntity) blockEntity;
-		if (blockEntityCable.getEnergy() <= 0) {
+		if (!((CableBlockEntity)blockEntity).isEnergized()) {
 			return;
 		}
-
+		
 		if (TechRebornConfig.uninsulatedElectrocutionDamage) {
 			if (type == TRContent.Cables.HV) {
 				entityIn.setOnFireFor(1);

--- a/src/main/java/techreborn/enet/ElectricNetwork.java
+++ b/src/main/java/techreborn/enet/ElectricNetwork.java
@@ -185,10 +185,6 @@ public final class ElectricNetwork {
 				.flatMap(entityFace -> entityFace.getConnectedPowerAcceptors().stream())
 				.collect(Collectors.toList());
 
-		for (CableBlockEntity entity : cableBlockEntities) {
-			powerAcceptors.addAll(entity.getConnectedPowerAcceptors());
-		}
-
 		double networkTransferCapacity = Math.min(networkTier.getMaxInput(), networkTier.getMaxOutput());
 
 		List<PowerAcceptorBlockEntityFace> fromList = powerAcceptors

--- a/src/main/java/techreborn/enet/ElectricNetwork.java
+++ b/src/main/java/techreborn/enet/ElectricNetwork.java
@@ -1,0 +1,257 @@
+/*
+ * This file is part of TechReborn, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2020 TechReborn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package techreborn.enet;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.util.Pair;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import reborncore.common.powerSystem.PowerAcceptorBlockEntity;
+import team.reborn.energy.EnergyTier;
+import techreborn.TechReborn;
+import techreborn.blockentity.cable.CableBlockEntity;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ElectricNetwork {
+	private int network_id;
+	private EnergyTier network_tier;
+	private HashSet<CableBlockEntity> enetCableBEs = new HashSet<>();
+	private boolean isDirty;
+	private boolean isEnergized;
+
+	public ElectricNetwork(int id, EnergyTier tier) {
+		network_id = id;
+		network_tier = tier;
+		isDirty = true;
+	}
+
+	public int getId() {
+		return network_id;
+	}
+
+	public boolean isEmpty() {
+		return enetCableBEs.isEmpty();
+	}
+
+	public void addBlockEntity(CableBlockEntity entity) {
+		this.enetCableBEs.add(entity);
+		isDirty = true;
+	}
+
+	public void removeBlockEntity(CableBlockEntity entity) {
+		this.enetCableBEs.remove(entity);
+		isDirty = true;
+	}
+
+	public void tick() {
+		if (this.isEmpty()) {
+			return;
+		}
+
+		if (isDirty) {
+			TechReborn.LOGGER.debug("Electric Network {} is dirty, checking for network and connection changes", network_id);
+			this.walkNetwork();
+
+			isDirty = false;
+		}
+
+		this.distributePower();
+	}
+
+	public boolean isEnergized() {
+		return isEnergized;
+	}
+
+	private void walkNetwork() {
+		// If the network is empty, why bother?
+		if (enetCableBEs.isEmpty()) {
+			return;
+		}
+
+		TechReborn.LOGGER.debug("Walking the Electric Network to detect for changes in neighbors...");
+
+		// Keep track of the nodes we've seen and visited
+		HashSet<CableBlockEntity> seenNodes = new HashSet<>();
+		HashSet<CableBlockEntity> visitedNodes = new HashSet<>();
+
+		// "See" the first node in the list
+		CableBlockEntity firstNode = enetCableBEs.iterator().next();
+		TechReborn.LOGGER.debug("First node in the walk: {}", firstNode);
+		seenNodes.addAll(visitCableNode(firstNode, visitedNodes));
+
+		// "remainingNodesToVisit" is our seen nodes, excluding the ones we've visited
+		HashSet<CableBlockEntity> remainingNodesToVisit = new HashSet<>(seenNodes);
+
+		while (!remainingNodesToVisit.isEmpty()) {
+			for (CableBlockEntity nodeToVisit : remainingNodesToVisit) {
+				seenNodes.addAll(visitCableNode(nodeToVisit, visitedNodes));
+			}
+
+			remainingNodesToVisit.clear();
+			remainingNodesToVisit.addAll(seenNodes);
+			remainingNodesToVisit.removeAll(visitedNodes);
+		}
+
+		for (CableBlockEntity nodeConnected : seenNodes) {
+			if (nodeConnected.getElectricNetworkId() != network_id) {
+				TechReborn.LOGGER.debug(
+						"Block {} network change: {} -> {}",
+						nodeConnected.getPos().asLong(),
+						nodeConnected.getElectricNetworkId(),
+						network_id);
+
+				nodeConnected.setElectricNetwork(network_id);
+			}
+		}
+
+		TechReborn.LOGGER.debug(
+				"Starting purge of disconnected entities. Have {}, seen {}",
+				enetCableBEs.size(),
+				seenNodes.size());
+
+		HashSet<CableBlockEntity> nodesToRemove = new HashSet<>(enetCableBEs);
+		nodesToRemove.removeAll(seenNodes);
+
+		for (CableBlockEntity nodeRemoved : nodesToRemove) {
+			TechReborn.LOGGER.debug(
+					"Block {} being ejected from the network {}",
+					nodeRemoved.getPos().asLong(),
+					network_id);
+
+			nodeRemoved.setElectricNetwork(0);
+		}
+
+		TechReborn.LOGGER.debug("Finished walking network for cable connection changes.");
+	}
+
+	private HashSet<CableBlockEntity> visitCableNode(CableBlockEntity currentEntity, HashSet<CableBlockEntity> visitedNodes) {
+		visitedNodes.add(currentEntity);
+
+		HashSet<CableBlockEntity> seenNodes = new HashSet<>();
+
+		if (currentEntity != null) {
+			TechReborn.LOGGER.debug(
+					"Visiting node {} on behalf of {} ({} visited total)",
+					currentEntity.getPos().asLong(),
+					network_id,
+					visitedNodes.size());
+
+			seenNodes.add(currentEntity);
+
+			for (Direction face : Direction.values()) {
+				BlockPos blockToCheckPos = currentEntity.getPos().offset(face);
+				BlockEntity blockEntity = currentEntity.getWorld().getBlockEntity(blockToCheckPos);
+
+				if (!(blockEntity instanceof CableBlockEntity) || visitedNodes.contains(blockEntity)) {
+					continue;
+				}
+
+				CableBlockEntity targetEntity = (CableBlockEntity) blockEntity;
+
+				TechReborn.LOGGER.debug(
+						"Node {} is on network {}",
+						targetEntity.getPos().asLong(),
+						targetEntity.getElectricNetworkId());
+
+				if (currentEntity.canConnectTo(targetEntity)) {
+					TechReborn.LOGGER.debug("Seen another node -- {}", blockToCheckPos.asLong());
+					seenNodes.add(targetEntity);
+				}
+			}
+		}
+
+		return seenNodes;
+	}
+
+	private void distributePower() {
+		ArrayList<Pair<PowerAcceptorBlockEntity, Direction>> powerAcceptors = new ArrayList<>();
+
+		for (CableBlockEntity entity : enetCableBEs) {
+			powerAcceptors.addAll(entity.getConnectedPowerAcceptors());
+		}
+
+		double remainingTransfer = Math.min(network_tier.getMaxInput(), network_tier.getMaxOutput());
+
+		// Prioritize transferring energy to entities that cannot also supply it on the same connection side (like a buffer)
+		List<Pair<PowerAcceptorBlockEntity, Direction>> fromList = powerAcceptors
+				.stream()
+				.filter(v -> v.getLeft().canProvideEnergy(v.getRight()) && v.getLeft().getEnergy() > 0)
+				.sorted(Comparator.comparing(v -> v.getLeft().canAcceptEnergy(v.getRight()) ? 1 : 0))
+				.collect(Collectors.toList());
+
+		List<Pair<PowerAcceptorBlockEntity, Direction>> toList = powerAcceptors
+				.stream()
+				.filter(v -> v.getLeft().canAcceptEnergy(v.getRight()) && !v.getLeft().canProvideEnergy(v.getRight()) && v.getLeft().getFreeSpace() > 0)
+				.collect(Collectors.toList());
+
+		isEnergized = fromList.stream().anyMatch(v -> v.getLeft().canProvideEnergy(v.getRight()));
+
+		remainingTransfer = this.transferPower(fromList, toList, remainingTransfer);
+
+		if (remainingTransfer > 0) {
+			// Handle transfers directly from generators to buffers
+			fromList = powerAcceptors
+					.stream()
+					.filter(v -> v.getLeft().canProvideEnergy(v.getRight()) && !v.getLeft().canAcceptEnergy(v.getRight()))
+					.collect(Collectors.toList());
+
+			toList = powerAcceptors
+					.stream()
+					.filter(v -> v.getLeft().canAcceptEnergy(v.getRight()) && v.getLeft().canProvideEnergy(v.getRight()) && v.getLeft().getFreeSpace() > 0)
+					.collect(Collectors.toList());
+
+			this.transferPower(fromList, toList, remainingTransfer);
+		}
+	}
+
+	private double transferPower(List<Pair<PowerAcceptorBlockEntity, Direction>> fromList, List<Pair<PowerAcceptorBlockEntity, Direction>> toList, double transferLimit) {
+		double remainingTransfer = transferLimit;
+
+		for (Pair<PowerAcceptorBlockEntity, Direction> to : toList) {
+			for (Pair<PowerAcceptorBlockEntity, Direction> from : fromList) {
+				PowerAcceptorBlockEntity fromEntity = from.getLeft();
+				PowerAcceptorBlockEntity toEntity = to.getLeft();
+
+				if (fromEntity == toEntity) {
+					TechReborn.LOGGER.debug("Skipping power transfer as source and target are the same");
+					continue;
+				}
+
+				double transferAmount = Math.min(toEntity.getFreeSpace(), remainingTransfer);
+				double extracted = fromEntity.useEnergy(transferAmount);
+				toEntity.addEnergy(extracted);
+
+				remainingTransfer -= extracted;
+			}
+		}
+
+		return remainingTransfer;
+	}
+}

--- a/src/main/java/techreborn/enet/ElectricNetwork.java
+++ b/src/main/java/techreborn/enet/ElectricNetwork.java
@@ -217,7 +217,6 @@ public final class ElectricNetwork {
 		for (PowerAcceptorBlockEntityFace to : toList) {
 			for (PowerAcceptorBlockEntityFace from : fromList) {
 				if (from.isSameEntity(to)) {
-					TechReborn.LOGGER.debug("Skipping power transfer as source and target are the same");
 					continue;
 				}
 

--- a/src/main/java/techreborn/enet/ElectricNetwork.java
+++ b/src/main/java/techreborn/enet/ElectricNetwork.java
@@ -34,11 +34,12 @@ import techreborn.blockentity.cable.CableBlockEntity;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public final class ElectricNetwork {
 	private final EnergyTier networkTier;
-	private final HashSet<CableBlockEntity> cableBlockEntities = new HashSet<>();
+	private final Set<CableBlockEntity> cableBlockEntities = new HashSet<>();
 	private boolean isDirty;
 	private boolean isEnergized;
 
@@ -127,23 +128,21 @@ public final class ElectricNetwork {
 
 		cableBlockEntities
 				.stream()
-				.filter(node -> !seenNodes.contains(node))
+				.filter(node -> !seenNodes.contains(node) && node != null)
 				.collect(Collectors.toList())
 				.forEach(node -> {
-					if (node != null) {
-						TechReborn.LOGGER.debug(
-								"Block {} being ejected from the network {}",
-								node,
-								this);
+					TechReborn.LOGGER.debug(
+							"Block {} being ejected from the network {}",
+							node,
+							this);
 
-						node.setElectricNetwork(null);
-					}
+					node.setElectricNetwork(null);
 				});
 
 		TechReborn.LOGGER.debug("Finished walking network for cable connection changes.");
 	}
 
-	private HashSet<CableBlockEntity> visitCableNode(CableBlockEntity currentEntity, HashSet<CableBlockEntity> visitedNodes) {
+	private Set<CableBlockEntity> visitCableNode(CableBlockEntity currentEntity, HashSet<CableBlockEntity> visitedNodes) {
 		visitedNodes.add(currentEntity);
 
 		HashSet<CableBlockEntity> seenNodes = new HashSet<>();

--- a/src/main/java/techreborn/enet/ElectricNetwork.java
+++ b/src/main/java/techreborn/enet/ElectricNetwork.java
@@ -128,13 +128,16 @@ public final class ElectricNetwork {
 		cableBlockEntities
 				.stream()
 				.filter(node -> !seenNodes.contains(node))
+				.collect(Collectors.toList())
 				.forEach(node -> {
-					TechReborn.LOGGER.debug(
-							"Block {} being ejected from the network {}",
-							node.getPos().asLong(),
-							this);
+					if (node != null) {
+						TechReborn.LOGGER.debug(
+								"Block {} being ejected from the network {}",
+								node,
+								this);
 
-					node.setElectricNetwork(null);
+						node.setElectricNetwork(null);
+					}
 				});
 
 		TechReborn.LOGGER.debug("Finished walking network for cable connection changes.");

--- a/src/main/java/techreborn/enet/ElectricNetworkManager.java
+++ b/src/main/java/techreborn/enet/ElectricNetworkManager.java
@@ -52,10 +52,7 @@ public final class ElectricNetworkManager implements ServerTickCallback {
 			network.tick();
 
 			if (network.isEmpty()) {
-				TechReborn.LOGGER.debug(
-						"Electric Network {} is empty, removed (total: {})",
-						network,
-						electricNetworks.size());
+				TechReborn.LOGGER.debug("Electric Network {} is empty, removed", network);
 			}
 
 			return network.isEmpty();

--- a/src/main/java/techreborn/enet/ElectricNetworkManager.java
+++ b/src/main/java/techreborn/enet/ElectricNetworkManager.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of TechReborn, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2020 TechReborn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package techreborn.enet;
+
+import net.fabricmc.fabric.api.event.registry.BlockConstructedCallback;
+import net.fabricmc.fabric.api.event.server.ServerTickCallback;
+import net.minecraft.block.Block;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.World;
+import team.reborn.energy.EnergyTier;
+import techreborn.TechReborn;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class ElectricNetworkManager implements ServerTickCallback {
+	public static ElectricNetworkManager INSTANCE;
+
+	private int lastId = 0;
+	private HashMap<Integer, ElectricNetwork> electricNetworks = new HashMap<>();
+
+	public ElectricNetworkManager() {
+		ServerTickCallback.EVENT.register(this::tick);
+	}
+
+	public static void init() {
+		INSTANCE = new ElectricNetworkManager();
+	}
+
+	@Override
+	public void tick(MinecraftServer minecraftServer) {
+		ArrayList<Integer> networksToRemove = new ArrayList<>();
+
+		for (ElectricNetwork currentNetwork: electricNetworks.values()) {
+			currentNetwork.tick();
+
+			if (currentNetwork.isEmpty()) {
+				networksToRemove.add(currentNetwork.getId());
+			}
+		}
+
+		for (Integer networkId: networksToRemove) {
+			electricNetworks.remove(networkId);
+
+			TechReborn.LOGGER.debug(
+					"Electric Network {} is empty, removed (total: {})",
+					networkId,
+					electricNetworks.size());
+		}
+	}
+
+	public ElectricNetwork getNetwork(int id, EnergyTier tier) {
+		if (electricNetworks.containsKey(id)) {
+			return electricNetworks.get(id);
+		}
+
+		return this.createAndTrackNetwork(id, tier);
+	}
+
+	public ElectricNetwork newNetwork(World world, EnergyTier tier) {
+		return this.createAndTrackNetwork(++lastId, tier);
+	}
+
+	private ElectricNetwork createAndTrackNetwork(int id, EnergyTier tier) {
+		ElectricNetwork newNetwork = new ElectricNetwork(id, tier);
+		electricNetworks.put(id, newNetwork);
+
+		TechReborn.LOGGER.debug("Created new electric network ID: {} (total: {})", id, electricNetworks.size());
+
+		return newNetwork;
+	}
+}

--- a/src/main/java/techreborn/enet/ElectricNetworkManager.java
+++ b/src/main/java/techreborn/enet/ElectricNetworkManager.java
@@ -30,12 +30,12 @@ import team.reborn.energy.EnergyTier;
 import techreborn.TechReborn;
 
 import java.util.HashSet;
+import java.util.Set;
 
 public final class ElectricNetworkManager implements ServerTickCallback {
 	public static ElectricNetworkManager INSTANCE;
 
-	private final HashSet<ElectricNetwork> electricNetworks = new HashSet<>();
-	private final HashSet<ElectricNetwork> pendingNetworks = new HashSet<>();
+	private final Set<ElectricNetwork> electricNetworks = new HashSet<>();
 
 	private ElectricNetworkManager() {
 		ServerTickCallback.EVENT.register(this::tick);
@@ -49,9 +49,6 @@ public final class ElectricNetworkManager implements ServerTickCallback {
 
 	@Override
 	public void tick(MinecraftServer minecraftServer) {
-		electricNetworks.addAll(pendingNetworks);
-		pendingNetworks.clear();
-
 		electricNetworks.removeIf(network -> {
 			network.tick();
 
@@ -65,7 +62,7 @@ public final class ElectricNetworkManager implements ServerTickCallback {
 
 	public ElectricNetwork newNetwork(EnergyTier tier) {
 		ElectricNetwork newNetwork = new ElectricNetwork(tier);
-		pendingNetworks.add(newNetwork);
+		electricNetworks.add(newNetwork);
 
 		TechReborn.LOGGER.debug(
 				"Enqueued new electric network ID: {}",

--- a/src/main/java/techreborn/enet/ElectricNetworkManager.java
+++ b/src/main/java/techreborn/enet/ElectricNetworkManager.java
@@ -35,6 +35,7 @@ public final class ElectricNetworkManager implements ServerTickCallback {
 	public static ElectricNetworkManager INSTANCE;
 
 	private final HashSet<ElectricNetwork> electricNetworks = new HashSet<>();
+	private final HashSet<ElectricNetwork> pendingNetworks = new HashSet<>();
 
 	private ElectricNetworkManager() {
 		ServerTickCallback.EVENT.register(this::tick);
@@ -48,6 +49,9 @@ public final class ElectricNetworkManager implements ServerTickCallback {
 
 	@Override
 	public void tick(MinecraftServer minecraftServer) {
+		electricNetworks.addAll(pendingNetworks);
+		pendingNetworks.clear();
+
 		electricNetworks.removeIf(network -> {
 			network.tick();
 
@@ -61,12 +65,11 @@ public final class ElectricNetworkManager implements ServerTickCallback {
 
 	public ElectricNetwork newNetwork(EnergyTier tier) {
 		ElectricNetwork newNetwork = new ElectricNetwork(tier);
-		electricNetworks.add(newNetwork);
+		pendingNetworks.add(newNetwork);
 
 		TechReborn.LOGGER.debug(
-				"Created new electric network ID: {} (total: {})",
-				newNetwork,
-				electricNetworks.size());
+				"Enqueued new electric network ID: {}",
+				newNetwork);
 
 		return newNetwork;
 	}

--- a/src/main/java/techreborn/enet/PowerAcceptorBlockEntityFace.java
+++ b/src/main/java/techreborn/enet/PowerAcceptorBlockEntityFace.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of TechReborn, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2020 TechReborn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package techreborn.enet;
 
 import net.minecraft.util.math.Direction;

--- a/src/main/java/techreborn/enet/PowerAcceptorBlockEntityFace.java
+++ b/src/main/java/techreborn/enet/PowerAcceptorBlockEntityFace.java
@@ -1,0 +1,36 @@
+package techreborn.enet;
+
+import net.minecraft.util.math.Direction;
+import reborncore.common.powerSystem.PowerAcceptorBlockEntity;
+
+public class PowerAcceptorBlockEntityFace {
+	private final PowerAcceptorBlockEntity entity;
+	private final Direction face;
+
+	public PowerAcceptorBlockEntityFace(PowerAcceptorBlockEntity entity, Direction face) {
+		this.entity = entity;
+		this.face = face;
+	}
+
+	public boolean canAcceptEnergy() {
+		return entity.canAcceptEnergy(face);
+	}
+
+	public boolean canProvideEnergy() {
+		return entity.canProvideEnergy(face);
+	}
+
+	public double getEnergy() {
+		return entity.getEnergy();
+	}
+
+	public double getFreeSpace() { return entity.getFreeSpace(); }
+
+	public boolean hasFreeSpace() { return getFreeSpace() > 0; }
+
+	public double useEnergy(double amount) { return entity.useEnergy(amount); }
+
+	public double addEnergy(double amount) { return entity.addEnergy(amount); }
+
+	public boolean isSameEntity(PowerAcceptorBlockEntityFace other) { return entity == other.entity; }
+}


### PR DESCRIPTION
**Work in progress. This is not a backwards compatible change.**

Running Tech Reborn 1.15 on Fabric, we saw issues with long (100+ block) power networks where power would "ping pong" along the network and never reach the target machines. This is a change to not treat each individual cable block as a separate Energy entity but instead to treat a set of connected cables as a single network unit.

This is a **breaking change**.  Cables of a different tier will no longer directly connect and the use of transformers is required. Insulated and bare cables on the same tier will connect.

This is my first Java/Minecraft modding experience so please let me know if I need to make changes to ensure it doesn't negatively impact servers or clients.