### PR TITLE
Fix crash opening GUIs on dedicated servers

### DIFF
--- a/src/main/java/techreborn/client/GuiType.java
+++ b/src/main/java/techreborn/client/GuiType.java
@@ -144,14 +144,12 @@ public final class GuiType<T extends BlockEntity> implements IMachineGuiHandler 
 
 	private final Identifier identifier;
 	private final Supplier<Supplier<GuiFactory<T>>> guiFactory;
-	private final ScreenHandlerRegistry.ExtendedClientHandlerFactory<BuiltScreenHandler> screenHandlerFactory;
 	private final ScreenHandlerType<BuiltScreenHandler> screenHandlerType;
 
 	private GuiType(Identifier identifier, Supplier<Supplier<GuiFactory<T>>> factorySupplierMeme) {
 		this.identifier = identifier;
 		this.guiFactory = factorySupplierMeme;
-		this.screenHandlerFactory = getScreenHandlerFactory();
-		this.screenHandlerType = ScreenHandlerRegistry.registerExtended(identifier, screenHandlerFactory);
+		this.screenHandlerType = ScreenHandlerRegistry.registerExtended(identifier, getScreenHandlerFactory());
 		RebornCore.clientOnly(() -> () -> ScreenRegistry.register(screenHandlerType, getGuiFactory()));
 	}
 
@@ -190,9 +188,10 @@ public final class GuiType<T extends BlockEntity> implements IMachineGuiHandler 
 				@Nullable
 				@Override
 				public ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity player) {
-					PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
-					buf.writeBlockPos(pos);
-					return screenHandlerFactory.create(syncId, inv, buf);
+					final BlockEntity blockEntity = player.world.getBlockEntity(pos);
+					BuiltScreenHandler screenHandler = ((BuiltScreenHandlerProvider) blockEntity).createScreenHandler(syncId, player);
+					screenHandler.setType(screenHandlerType);
+					return screenHandler;
 				}
 			});
 		}


### PR DESCRIPTION
ExtendedClientHandlerFactory.create() is client-only.
Simply copy the relevant code into createMenu().

This is pretty terrible like the rest of the GUI code in GuiType.java, but this fixes the issue for now.

Fixes #2138.