### PR TITLE
Implement sun incidence angle scaling for solar panels

### DIFF
--- a/src/main/java/techreborn/client/gui/GuiSolar.java
+++ b/src/main/java/techreborn/client/gui/GuiSolar.java
@@ -32,6 +32,8 @@ import reborncore.client.gui.builder.GuiBase;
 import reborncore.client.screen.builder.BuiltScreenHandler;
 import techreborn.blockentity.generator.SolarPanelBlockEntity;
 
+import java.lang.Math;
+
 public class GuiSolar extends GuiBase<BuiltScreenHandler> {
 
 	SolarPanelBlockEntity blockEntity;
@@ -53,10 +55,13 @@ public class GuiSolar extends GuiBase<BuiltScreenHandler> {
 		final GuiBase.Layer layer = GuiBase.Layer.FOREGROUND;
 
 		builder.drawMultiEnergyBar(matrixStack, this, 156, 19, (int) blockEntity.getEnergy(), (int) blockEntity.getMaxPower(), mouseX, mouseY, 0, layer);
+		String angleStr = "--";
 
 		switch (blockEntity.getSunState()) {
 			case SolarPanelBlockEntity.DAYGEN:
 				builder.drawText(matrixStack, this, new TranslatableText("techreborn.message.daygen"), 10, 20, 15129632);
+				// Round here as well, so "90°" is visible at least for a short while
+				angleStr = String.valueOf((int) Math.round(blockEntity.incidenceAngle * 90)) + "°";
 				break;
 			case SolarPanelBlockEntity.NIGHTGEN:
 				builder.drawText(matrixStack, this, new TranslatableText("techreborn.message.nightgen"), 10, 20, 7566195);
@@ -66,7 +71,8 @@ public class GuiSolar extends GuiBase<BuiltScreenHandler> {
 				break;
 		}
 
-		builder.drawText(matrixStack, this, new LiteralText("Generating: " + blockEntity.getGenerationRate() + " E/t"), 10, 30, 0);
+		builder.drawText(matrixStack, this, new TranslatableText("techreborn.message.solarAngle", angleStr), 10, 30, 0);
+		builder.drawText(matrixStack, this, new TranslatableText("techreborn.message.generationRate", blockEntity.getGenerationRate()), 10, 40, 0);
 
 	}
 }

--- a/src/main/resources/assets/techreborn/lang/en_us.json
+++ b/src/main/resources/assets/techreborn/lang/en_us.json
@@ -697,6 +697,8 @@
   "techreborn.message.daygen": "Panel in direct sunlight",
   "techreborn.message.nightgen": "Panel in reduced sunlight",
   "techreborn.message.zerogen": "Panel obstructed from sky",
+  "techreborn.message.solarAngle": "Incidence angle: %s",
+  "techreborn.message.generationRate": "Generating: %d E/t",
 
   "techreborn.message.info.item.techreborn.overclocker_upgrade": "Increases speed at the cost of more energy",
   "techreborn.message.info.item.techreborn.transformer_upgrade": "Increase energy tier",


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/63550306/92331452-07271e00-f077-11ea-856c-29d94822114d.png)


Details can be found in the accompanying issue: #2127 .

Right now, solar panels are incredibly overpowered, pushing all other generator types into oblivion. This new feature will not entirely remedy this, and I feel that either solar panels need to be nerfed even further (by at least halving their output), or by generously buffing the fuel- and other regenerative-energy based power sources.

Regarding the implementation, I feel a bit conflicted about the hack I had to build in using the counter `int` that is increased every time the to-be-displayed contents (in this case, light angle and energy output) change, so the GUI is updated accordingly. I'm hoping for suggestions on how to do that in a less hacky way.

Also remember that despite this looking a bit dicey for a ticking entity, the angle calculations are only done every few ticks (20 I believe).

I have tested this successfully on dedicated server.