### PR TITLE
Opinionated recipe tweaks

### DIFF
--- a/src/main/resources/data/techreborn/recipes/crafting_table/parts/diamond_grinding_head.json
+++ b/src/main/resources/data/techreborn/recipes/crafting_table/parts/diamond_grinding_head.json
@@ -18,6 +18,6 @@
   },
   "result": {
     "item": "techreborn:diamond_grinding_head",
-    "count": 2
+    "count": 3
   }
 }

--- a/src/main/resources/data/techreborn/recipes/crafting_table/tool/painting_tool.json
+++ b/src/main/resources/data/techreborn/recipes/crafting_table/tool/painting_tool.json
@@ -2,15 +2,12 @@
   "type": "minecraft:crafting_shaped",
   "pattern": [
 	"BWB",
-	"NBN",
+	" B ",
 	" B "
   ],
   "key": {
 	"B": {
 	  "tag": "c:bronze_ingots"
-	},
-	"N": {
-	  "tag": "c:bronze_nuggets"
 	},
 	"W": {
 	  "tag": "minecraft:wool"

--- a/src/main/resources/data/techreborn/recipes/crafting_table/tool/wrench.json
+++ b/src/main/resources/data/techreborn/recipes/crafting_table/tool/wrench.json
@@ -1,16 +1,13 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "BNB",
-    "NBN",
+    "B B",
+    " B ",
     " B "
   ],
   "key": {
     "B": {
       "tag": "c:bronze_ingots"
-    },
-    "N": {
-      "tag": "c:bronze_nuggets"
     }
   },
   "result": {


### PR DESCRIPTION
This PR does two things.
1) Bronze Nuggets have been scrubbed from recipes.
2) The Diamond Grinding Head recipe now has 3 output instead of 2.

My justification for the first is that it feels like a holdover from the Forge days. 
Back when TR had to worry about intercompat with IC2, the Wrench recipe made tons of sense.
Nowadays, at best, the player will craft one wrench and one painting tool and have 4 bronze nuggets leftover, sitting alone in a chest somewhere.
The solution is either to introduce more bronze nuggets into recipes, or just remove them from the existing recipes. I did the latter.

The second change is for similar reasons.
Diamond Grinding Heads are crafted in 2, but the Industrial Grinder requires 3 of them. I'm not aware of any other use for them. 
Thus you end up with 1 grinding head, like the bronze nuggets, sitting sadly in a chest.
My change _does_ mean the Industrial Grinder is 5 diamonds cheaper. I consider this a feature; the infrastructure costs and Raw Iron needed for the machine already pick up the slack, making the recipe expensive enough.