### PR TITLE
Add rubber planks to #c:planks_that_burn (Blockus compatibility)

### DIFF
--- a/src/main/resources/data/c/tags/items/planks_that_burn.json
+++ b/src/main/resources/data/c/tags/items/planks_that_burn.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "techreborn:rubber_planks"
+  ]
+}


### PR DESCRIPTION
This pull request simply adds rubber planks to the tag `#c:planks_that_burn` so that they can be used in [Blockus'](https://github.com/Brandcraf06/Blockus) charred planks recipe.