### PR TITLE
Use tags in steel and refined iron blast furnace recipes

### DIFF
--- a/src/main/resources/data/c/tags/items/planks_that_burn.json
+++ b/src/main/resources/data/c/tags/items/planks_that_burn.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "techreborn:rubber_planks"
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/blast_furnace/refined_iron_ingot_from_iron_ore.json
+++ b/src/main/resources/data/techreborn/recipes/blast_furnace/refined_iron_ingot_from_iron_ore.json
@@ -5,7 +5,7 @@
 	"heat": 1000,
 	"ingredients": [
 		{
-			"item": "minecraft:iron_ore"
+			"tag": "c:iron_ores"
 		},
 		{
 			"fluid": "techreborn:calcium_carbonate",

--- a/src/main/resources/data/techreborn/recipes/blast_furnace/steel_ingot_from_refined_iron.json
+++ b/src/main/resources/data/techreborn/recipes/blast_furnace/steel_ingot_from_refined_iron.json
@@ -8,7 +8,7 @@
 			"item": "techreborn:refined_iron_ingot"
 		},
 		{
-			"item": "techreborn:coal_dust",
+			"tag": "c:coal_dusts",
 			"count": 4
 		}
 	],


### PR DESCRIPTION
This pull request makes the blast furnace's steel from refined iron and coal dust recipe use `#c:coal_dusts` for compatibility with coals dusts from other mods like Astromine, and also makes its refined iron from iron ore recipe use `#c:iron_ores` for compatibility with modded iron ore variants, like those from UnEarthed.