### PR TITLE
Fix Omni-Tool, Rockcutter and Jackhammer being damageable

### DIFF
--- a/src/main/java/techreborn/items/tool/JackhammerItem.java
+++ b/src/main/java/techreborn/items/tool/JackhammerItem.java
@@ -57,7 +57,7 @@ public class JackhammerItem extends PickaxeItem implements EnergyHolder, ItemDur
 	protected final float unpoweredSpeed = 0.5F;
 
 	public JackhammerItem(int energyCapacity, EnergyTier tier, int cost) {
-		super(ToolMaterials.DIAMOND, (int) ToolMaterials.DIAMOND.getAttackDamage(), 1F, new Item.Settings().group(TechReborn.ITEMGROUP).maxCount(1));
+		super(ToolMaterials.DIAMOND, (int) ToolMaterials.DIAMOND.getAttackDamage(), 1F, new Item.Settings().group(TechReborn.ITEMGROUP).maxCount(1).maxDamage(-1));
 		this.maxCharge = energyCapacity;
 		this.tier = tier;
 		this.cost = cost;
@@ -111,6 +111,11 @@ public class JackhammerItem extends PickaxeItem implements EnergyHolder, ItemDur
 	}
 
 	// Item
+	@Override
+	public boolean isDamageable() {
+		return false;
+	}
+
 	@Override
 	public boolean isEnchantable(ItemStack stack) {
 		return true;

--- a/src/main/java/techreborn/items/tool/advanced/RockCutterItem.java
+++ b/src/main/java/techreborn/items/tool/advanced/RockCutterItem.java
@@ -55,7 +55,7 @@ public class RockCutterItem extends PickaxeItem implements EnergyHolder, ItemDur
 
 	// 400k FE with 1k FE\t charge rate
 	public RockCutterItem() {
-		super(ToolMaterials.DIAMOND, 1, 1, new Item.Settings().group(TechReborn.ITEMGROUP).maxCount(1));
+		super(ToolMaterials.DIAMOND, 1, 1, new Item.Settings().group(TechReborn.ITEMGROUP).maxCount(1).maxDamage(-1));
 	}
 
 	// PickaxeItem

--- a/src/main/java/techreborn/items/tool/industrial/OmniToolItem.java
+++ b/src/main/java/techreborn/items/tool/industrial/OmniToolItem.java
@@ -69,7 +69,7 @@ public class OmniToolItem extends PickaxeItem implements EnergyHolder, ItemDurab
 
 	// 4M FE max charge with 1k charge rate
 	public OmniToolItem() {
-		super(ToolMaterials.DIAMOND, 3, 1, new Item.Settings().group(TechReborn.ITEMGROUP).maxCount(1));
+		super(ToolMaterials.DIAMOND, 3, 1, new Item.Settings().group(TechReborn.ITEMGROUP).maxCount(1).maxDamage(-1));
 		this.miningLevel = MiningLevel.DIAMOND.intLevel;
 	}
 


### PR DESCRIPTION
Just like https://github.com/TechReborn/TechReborn/pull/1970.
Mojang still doesn't call `Item.isDamageable()` inside `ItemStack.isDamageable()`, which does affect some mod interactions like with FallingTree, so here's a fix.

The Jackhammer was unbreakable before, but I assume it was accidentally made damageable in https://github.com/TechReborn/TechReborn/commit/0c6513b2527e9897e5e5eebb6c8d2e6f689e206a?