### PR TITLE
Update player head with changed nickname

### DIFF
--- a/src/main/resources/data/techreborn/recipes/scrapbox/auto/player_head_2.json
+++ b/src/main/resources/data/techreborn/recipes/scrapbox/auto/player_head_2.json
@@ -11,7 +11,7 @@
       "item": "minecraft:player_head",
       "count": 3,
       "nbt": {
-        "SkullOwner": "ProfProspector"
+        "SkullOwner": "ProspectorDev"
       }
     }
   ],


### PR DESCRIPTION
ProfProspector's Head has small lagging and broken(default player head) because nickname changed to `ProspectorDev`