### PR TITLE
Fix ConcurrentModificationException due to REI async search

### DIFF
--- a/src/main/java/techreborn/events/StackToolTipHandler.java
+++ b/src/main/java/techreborn/events/StackToolTipHandler.java
@@ -27,6 +27,7 @@ package techreborn.events;
 import com.google.common.collect.Maps;
 import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
 import net.minecraft.block.Block;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.item.Item;
@@ -34,6 +35,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 import net.minecraft.util.registry.Registry;
 import reborncore.common.BaseBlockEntityProvider;
+import techreborn.TechReborn;
 import techreborn.init.TRContent;
 import techreborn.items.UpgradeItem;
 import techreborn.utils.ToolTipAssistUtils;
@@ -53,7 +55,12 @@ public class StackToolTipHandler implements ItemTooltipCallback {
 	public void getTooltip(ItemStack stack, TooltipContext tooltipContext, List<Text> tooltipLines) {
 		Item item = stack.getItem();
 
-		if (!ITEM_ID.computeIfAbsent(item, this::isTRItem))
+		// Can currently be executed by a ForkJoinPool.commonPool-worker when REI is in async search mode
+		// We skip this method until a thread-safe solution is in place
+		if (!MinecraftClient.getInstance().isOnThread())
+			return;
+
+		if (!ITEM_ID.computeIfAbsent(item, StackToolTipHandler::isTRItem))
 			return;
 
 		// Machine info and upgrades helper section
@@ -71,7 +78,7 @@ public class StackToolTipHandler implements ItemTooltipCallback {
 		}
 	}
 
-	private boolean isTRItem(Item item) {
+	private static boolean isTRItem(Item item) {
 		return Registry.ITEM.getId(item).getNamespace().equals("techreborn");
 	}
 }


### PR DESCRIPTION
## Description

This is more of a band-aid solution to a slightly bigger problem:
`ItemTooltipCallback.getTooltip()` can be executed by worker threads when REI is in async search mode and it is not completely thread-safe.

Going through it:
- `ITEM_ID` is not thread-safe and `computeIfAbsent` can cause a `ConcurrentModificationException` (see the log below)
- `isTRItem` uses `Registry.ITEM` which is not thread-safe (uses `BiMap`), this shouldn't be a big issue since the registry doesn't change after init and it can't throw
- `item.getTranslationKey()`: can use `Registry.ITEM` too
- `ToolTipAssistUtils.getUpgradeStats`: accesses `TechRebornConfig` which is not thread-safe, but also unlikely to change

So except `ITEM_ID`, it should work well enough as-is - also, there's little one can do to make access to `Registry.ITEM` thread-safe.

## Changes

- Use a `ConcurrentHashMap` for `ITEM_ID`
- make `isTRItem` `static`, simply because it can be `static`

### Log (formatted to fit)

> \[ForkJoinPool.commonPool-worker-11/INFO]:
> java.util.ConcurrentModificationException
 at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1225)
 at techreborn.events.StackToolTipHandler.getTooltip(StackToolTipHandler.java:56)
 at net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback.lambda$static$0(ItemTooltip
 at net.minecraft.class_1799.handler$cli001$getTooltip(class_1799.java:4155)
 at net.minecraft.class_1799.method_7950(class_1799.java:767)
 at me.shedaniel.rei.impl.ItemEntryStack.tryGetItemStackToolTip(ItemEntryStack.java:400)
 at me.shedaniel.rei.impl.ItemEntryStack.getTooltip(ItemEntryStack.java:289)
 at me.shedaniel.rei.impl.SearchArgument.tryGetEntryStackTooltip(SearchArgument.java:180)
 at me.shedaniel.rei.impl.search.TooltipArgument.matches(TooltipArgument.java:71)
 at me.shedaniel.rei.impl.search.TooltipArgument.matches(TooltipArgument.java:42)
 at me.shedaniel.rei.impl.SearchArgument.matches(SearchArgument.java:176)
 at me.shedaniel.rei.impl.SearchArgument.canSearchTermsBeAppliedTo(SearchArgument.java:164
 at me.shedaniel.rei.gui.widget.EntryListWidget.canLastSearchTermsBeAppliedTo(EntryListWid
 at me.shedaniel.rei.gui.widget.EntryListWidget.lambda$updateSearch$6(EntryListWidget.java
 at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.jav
 at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.ja
 at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:295)
 at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1
 at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1665)
 at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1598)
 at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
