### PR TITLE
Fix relative path resolution in build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,7 +311,7 @@ task compileRecipes {
 	def smeltingPath = recipePath + "/smelting"
 	def blastingPath = recipePath + "/blasting"
 
-    doLast {
+	doLast {
 		// Add any recipe filenames that don't match the regex here
 		String[] whitelist = []
 		def pattern = ~'^\\w+_(ingot(_from_dust)?)\\.json$'
@@ -325,12 +325,12 @@ task compileRecipes {
 					recipe.type = "minecraft:blasting"
 					recipe.cookingtime = recipe.cookingtime / 2
 
-					File output = new File(blastingPath, it.name)
+					File output = file(new File(blastingPath, it.name))
 					output.write(JsonOutput.prettyPrint(JsonOutput.toJson(recipe)))
 				}
 			}
 		}
-    }
+	}
 }
 
 // A task to ensure that the version being released has not already been released.


### PR DESCRIPTION
This is a really small build fix.
`new File(relativePath)` (or `new File(relativePath, child)`) is (apparently) not guaranteed to be based off of the project directory and thus the `compileRecipes` task can fail.

I'm on a Windows machine and building via `gradlew build` or using IntelliJ IDEA 2020.3.3 works just fine.
Using IDEA 2021.1 however breaks the build, since it bases the path off of `%userprofile%\.gradle\daemon\6.8.3` for some unknown reason, which could probably be considered a bug - still, it shouldn't hurt fixing the build itself.

I think it could also be fixed by prepending the `recipePath` with `${projectDir}` since [`file()`](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#file-java.lang.Object-) "Resolves a file path relative to the project directory of this project".