### PR TITLE
Make 1 copper block give 9 copper plates

### DIFF
--- a/src/main/resources/data/techreborn/recipes/compressor/copper_plate_from_block.json
+++ b/src/main/resources/data/techreborn/recipes/compressor/copper_plate_from_block.json
@@ -10,7 +10,7 @@
     "results": [
         {
             "item": "techreborn:copper_plate",
-            "count": 4
+            "count": 9
         }
     ]
 }


### PR DESCRIPTION
Copper blocks were changed to 9 copper ingots at some point during the snapshots.