### PR TITLE
Add DashLoader compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,12 @@ repositories {
 			includeGroup "curse.maven"
 		}
 	}
+    maven {
+        url = "https://maven.oskarstrom.net"
+        content {
+            includeGroup "net.oskarstrom"
+        }
+    }
 	maven {
 		url "https://maven.shedaniel.me/"
 	}
@@ -146,6 +152,8 @@ dependencies {
     optionalDependency "me.shedaniel:RoughlyEnoughItems-fabric:6.0.262-alpha"
     disabledOptionalDependency ('com.github.emilyploszaj:trinkets:2.6.7')
     disabledOptionalDependency "com.github.dexman545:autoswitch-api:-SNAPSHOT"
+    optionalDependency 'net.oskarstrom:DashLoader:2.0'
+
 }
 
 def optionalDependency(String dep) {

--- a/src/main/java/techreborn/compat/dashloader/DashDynamicBucketBakedModel.java
+++ b/src/main/java/techreborn/compat/dashloader/DashDynamicBucketBakedModel.java
@@ -1,0 +1,26 @@
+package techreborn.compat.dashloader;
+
+import net.oskarstrom.dashloader.DashRegistry;
+import net.oskarstrom.dashloader.api.annotation.DashConstructor;
+import net.oskarstrom.dashloader.api.annotation.DashObject;
+import net.oskarstrom.dashloader.api.enums.ConstructorMode;
+import net.oskarstrom.dashloader.model.DashModel;
+import techreborn.client.render.DynamicBucketBakedModel;
+
+@DashObject(DynamicBucketBakedModel.class)
+public class DashDynamicBucketBakedModel implements DashModel {
+
+	@DashConstructor(ConstructorMode.EMPTY)
+	public DashDynamicBucketBakedModel() {
+	}
+
+	@Override
+	public DynamicBucketBakedModel toUndash(DashRegistry registry) {
+		return new DynamicBucketBakedModel();
+	}
+
+	@Override
+	public int getStage() {
+		return 0;
+	}
+}

--- a/src/main/java/techreborn/compat/dashloader/DashDynamicCellBakedModel.java
+++ b/src/main/java/techreborn/compat/dashloader/DashDynamicCellBakedModel.java
@@ -1,0 +1,26 @@
+package techreborn.compat.dashloader;
+
+import net.oskarstrom.dashloader.DashRegistry;
+import net.oskarstrom.dashloader.api.annotation.DashConstructor;
+import net.oskarstrom.dashloader.api.annotation.DashObject;
+import net.oskarstrom.dashloader.api.enums.ConstructorMode;
+import net.oskarstrom.dashloader.model.DashModel;
+import techreborn.client.render.DynamicCellBakedModel;
+
+@DashObject(DynamicCellBakedModel.class)
+public class DashDynamicCellBakedModel implements DashModel {
+
+	@DashConstructor(ConstructorMode.EMPTY)
+	public DashDynamicCellBakedModel() {
+	}
+
+	@Override
+	public DynamicCellBakedModel toUndash(DashRegistry registry) {
+		return new DynamicCellBakedModel();
+	}
+
+	@Override
+	public int getStage() {
+		return 0;
+	}
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,6 +26,12 @@
 	  "techreborn.compat.autoswitch.AutoSwitchApiImpl"
 	]
   },
+  "custom": {
+	"dashloader:customobject": [
+	  "techreborn.compat.dashloader.DashDynamicBucketBakedModel",
+	  "techreborn.compat.dashloader.DashDynamicCellBakedModel"
+	]
+  },
   "depends": {
     "fabricloader": ">=0.11.3",
 	"fabric": ">=0.34.10",


### PR DESCRIPTION
This commit adds DashLoader compatibility through their API. build.gradle file is like the only change that toucher TR everything else is separate and does not require DashLoader as a dependency with the mod. Closes #2443 