### PR TITLE
Enable overfill checking on fusion reactor energy stored

### DIFF
--- a/src/main/java/techreborn/blockentity/machine/multiblock/FusionControlComputerBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/multiblock/FusionControlComputerBlockEntity.java
@@ -70,7 +70,6 @@ public class FusionControlComputerBlockEntity extends GenericMachineBlockEntity 
 
 	public FusionControlComputerBlockEntity(BlockPos pos, BlockState state) {
 		super(TRBlockEntities.FUSION_CONTROL_COMPUTER, pos, state, "FusionControlComputer", -1, -1, TRContent.Machine.FUSION_CONTROL_COMPUTER.block, -1);
-		checkOverfill = false;
 		this.inventory = new RebornInventory<>(3, "FusionControlComputerBlockEntity", 64, this);
 	}
 


### PR DESCRIPTION
It's not clear why the overfill checking was disabled on the Fusion Reactor, but this PR re-enables it so that the reactor never overfills on energy.

(This may have been a deliberate design decision - if so, feel free to close this PR out with extreme prejudice.) :)