### PR TITLE
Fix LESU Controller crash on placement

### DIFF
--- a/src/main/java/techreborn/blockentity/storage/energy/lesu/LapotronicSUBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/energy/lesu/LapotronicSUBlockEntity.java
@@ -117,15 +117,6 @@ public class LapotronicSUBlockEntity extends EnergyStorageBlockEntity implements
 		}
 	}
 
-	@Override
-	public Direction getFacingEnum() {
-		Block block = world.getBlockState(pos).getBlock();
-		if (block instanceof LapotronicSUBlock) {
-			return ((LapotronicSUBlock) block).getFacing(world.getBlockState(pos));
-		}
-		return null;
-	}
-
 	// IContainerProvider
 	@Override
 	public BuiltScreenHandler createScreenHandler(int syncID, final PlayerEntity player) {


### PR DESCRIPTION
I removed the getFacingEnum override since it's functionally identical to the super-classes method AND it's missing the check for null world.