### PR TITLE
Fix 2504: Don't check energy capacity when reading NBT, but check after applying upgrades

### DIFF
--- a/RebornCore/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
+++ b/RebornCore/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
@@ -155,6 +155,7 @@ public class MachineBaseBlockEntity extends BlockEntity implements BlockEntityTi
 					((IUpgrade) stack.getItem()).process(this, this, stack);
 				}
 			}
+			afterUpgradesApplication();
 		}
 		if (world == null || world.isClient) {
 			return;
@@ -173,6 +174,9 @@ public class MachineBaseBlockEntity extends BlockEntity implements BlockEntityTi
 	public void resetUpgrades() {
 		resetPowerMulti();
 		resetSpeedMulti();
+	}
+
+	protected void afterUpgradesApplication() {
 	}
 
 	public int getFacingInt() {

--- a/RebornCore/src/main/java/reborncore/common/powerSystem/PowerAcceptorBlockEntity.java
+++ b/RebornCore/src/main/java/reborncore/common/powerSystem/PowerAcceptorBlockEntity.java
@@ -41,7 +41,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import reborncore.api.IListInfoProvider;
 import reborncore.common.blockentity.MachineBaseBlockEntity;

--- a/RebornCore/src/main/java/reborncore/common/powerSystem/PowerAcceptorBlockEntity.java
+++ b/RebornCore/src/main/java/reborncore/common/powerSystem/PowerAcceptorBlockEntity.java
@@ -41,6 +41,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import reborncore.api.IListInfoProvider;
 import reborncore.common.blockentity.MachineBaseBlockEntity;
@@ -346,7 +347,8 @@ public abstract class PowerAcceptorBlockEntity extends MachineBaseBlockEntity im
 		super.readNbt(tag);
 		NbtCompound data = tag.getCompound("PowerAcceptor");
 		if (shouldHandleEnergyNBT()) {
-			this.setStored(data.getLong("energy"));
+			// Bypass the overfill check in setStored() because upgrades have not yet been applied.
+			this.energyContainer.amount = data.getLong("energy");
 		}
 	}
 
@@ -365,6 +367,13 @@ public abstract class PowerAcceptorBlockEntity extends MachineBaseBlockEntity im
 		extraPowerStorage = 0;
 		extraTier = 0;
 		extraPowerInput = 0;
+	}
+
+	@Override
+	protected void afterUpgradesApplication() {
+		if (checkOverfill && getStored() > getMaxStoredPower()) {
+			setStored(getStored());
+		}
 	}
 
 	public long getStored() {


### PR DESCRIPTION
The added check after upgrades ensures that energy gets deleted if an upgrade is removed.