### PR TITLE
Fix 2509; reviewed all ticking entities to ensure consistency in checks

### DIFF
--- a/src/main/java/techreborn/blockentity/generator/BaseFluidGeneratorBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/generator/BaseFluidGeneratorBlockEntity.java
@@ -79,16 +79,11 @@ public abstract class BaseFluidGeneratorBlockEntity extends PowerAcceptorBlockEn
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
 		super.tick(world, pos, state, blockEntity);
-
-		if (world == null) {
+		if (world == null || world.isClient) {
 			return;
 		}
 
 		ticksSinceLastChange++;
-
-		if (world.isClient) {
-			return;
-		}
 
 		// Check cells input slot 2 time per second
 		if (ticksSinceLastChange >= 10) {

--- a/src/main/java/techreborn/blockentity/generator/LightningRodBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/generator/LightningRodBlockEntity.java
@@ -56,8 +56,7 @@ public class LightningRodBlockEntity extends PowerAcceptorBlockEntity implements
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
 		super.tick(world, pos, state, blockEntity);
-
-		if (world == null){
+		if (world == null || world.isClient){
 			return;
 		}
 

--- a/src/main/java/techreborn/blockentity/generator/SolarPanelBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/generator/SolarPanelBlockEntity.java
@@ -148,12 +148,7 @@ public class SolarPanelBlockEntity extends PowerAcceptorBlockEntity implements I
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
 		super.tick(world, pos, state, blockEntity);
-
-		if (world == null) {
-			return;
-		}
-
-		if (world.isClient) {
+		if (world == null || world.isClient) {
 			return;
 		}
 

--- a/src/main/java/techreborn/blockentity/generator/advanced/DragonEggSyphonBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/generator/advanced/DragonEggSyphonBlockEntity.java
@@ -65,23 +65,20 @@ public class DragonEggSyphonBlockEntity extends PowerAcceptorBlockEntity
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
 		super.tick(world, pos, state, blockEntity);
-
-		if (world == null) {
+		if (world == null || world.isClient) {
 			return;
 		}
 
-		if (!world.isClient) {
-			if (world.getBlockState(new BlockPos(pos.getX(), pos.getY() + 1, pos.getZ()))
-					.getBlock() == Blocks.DRAGON_EGG) {
-				if (tryAddingEnergy(TechRebornConfig.dragonEggSyphonEnergyPerTick))
-					lastOutput = world.getTime();
-			}
+		if (world.getBlockState(new BlockPos(pos.getX(), pos.getY() + 1, pos.getZ()))
+				.getBlock() == Blocks.DRAGON_EGG) {
+			if (tryAddingEnergy(TechRebornConfig.dragonEggSyphonEnergyPerTick))
+				lastOutput = world.getTime();
+		}
 
-			if (world.getTime() - lastOutput < 30 && !isActive()) {
-				world.setBlockState(pos, world.getBlockState(pos).with(BlockMachineBase.ACTIVE, true));
-			} else if (world.getTime() - lastOutput > 30 && isActive()) {
-				world.setBlockState(pos, world.getBlockState(pos).with(BlockMachineBase.ACTIVE, false));
-			}
+		if (world.getTime() - lastOutput < 30 && !isActive()) {
+			world.setBlockState(pos, world.getBlockState(pos).with(BlockMachineBase.ACTIVE, true));
+		} else if (world.getTime() - lastOutput > 30 && isActive()) {
+			world.setBlockState(pos, world.getBlockState(pos).with(BlockMachineBase.ACTIVE, false));
 		}
 	}
 

--- a/src/main/java/techreborn/blockentity/machine/misc/DrainBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/misc/DrainBlockEntity.java
@@ -56,7 +56,7 @@ public class DrainBlockEntity extends MachineBaseBlockEntity {
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
 		super.tick(world, pos, state, blockEntity);
-		if (world.isClient) {
+		if (world == null || world.isClient) {
 			return;
 		}
 

--- a/src/main/java/techreborn/blockentity/machine/multiblock/FluidReplicatorBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/multiblock/FluidReplicatorBlockEntity.java
@@ -75,12 +75,14 @@ public class FluidReplicatorBlockEntity extends GenericMachineBlockEntity implem
 	// TileGenericMachine
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
-		if (world == null){
+		super.tick(world, pos, state, blockEntity);
+		if (world == null || world.isClient){
 			return;
 		}
+
 		ticksSinceLastChange++;
 		// Check cells input slot 2 time per second
-		if (!world.isClient && ticksSinceLastChange >= 10) {
+		if (ticksSinceLastChange >= 10) {
 			if (!inventory.getStack(1).isEmpty()) {
 				FluidUtils.fillContainers(tank, inventory, 1, 2);
 				if (tank.isEmpty()){
@@ -90,8 +92,6 @@ public class FluidReplicatorBlockEntity extends GenericMachineBlockEntity implem
 			}
 			ticksSinceLastChange = 0;
 		}
-
-		super.tick(world, pos, state, blockEntity);
 	}
 
 	@Override

--- a/src/main/java/techreborn/blockentity/machine/multiblock/IndustrialGrinderBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/multiblock/IndustrialGrinderBlockEntity.java
@@ -78,20 +78,20 @@ public class IndustrialGrinderBlockEntity extends GenericMachineBlockEntity impl
 	// TilePowerAcceptor
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
-		if (world == null){
+		super.tick(world, pos, state, blockEntity);
+		if (world == null || world.isClient){
 			return;
 		}
+
 		ticksSinceLastChange++;
 		// Check cells input slot 2 time per second
-		if (!world.isClient && ticksSinceLastChange >= 10) {
+		if (ticksSinceLastChange >= 10) {
 			if (!inventory.getStack(1).isEmpty()) {
 				FluidUtils.drainContainers(tank, inventory, 1, 6);
 				FluidUtils.fillContainers(tank, inventory, 1, 6);
 			}
 			ticksSinceLastChange = 0;
 		}
-
-		super.tick(world, pos, state, blockEntity);
 	}
 
 	@Override

--- a/src/main/java/techreborn/blockentity/machine/multiblock/IndustrialSawmillBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/multiblock/IndustrialSawmillBlockEntity.java
@@ -78,21 +78,20 @@ public class IndustrialSawmillBlockEntity extends GenericMachineBlockEntity impl
 	// TileGenericMachine
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
-		if (world == null) {
+		super.tick(world, pos, state, blockEntity);
+		if (world == null || world.isClient) {
 			return;
 		}
+
 		ticksSinceLastChange++;
 		// Check cells input slot 2 time per second
-		if (!world.isClient && ticksSinceLastChange >= 10) {
+		if (ticksSinceLastChange >= 10) {
 			if (!inventory.getStack(1).isEmpty()) {
 				FluidUtils.drainContainers(tank, inventory, 1, 5);
 				FluidUtils.fillContainers(tank, inventory, 1, 5);
 			}
 			ticksSinceLastChange = 0;
 		}
-
-		super.tick(world, pos, state, blockEntity);
-
 	}
 
 	// TilePowerAcceptor

--- a/src/main/java/techreborn/blockentity/machine/tier1/RollingMachineBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/tier1/RollingMachineBlockEntity.java
@@ -105,7 +105,7 @@ public class RollingMachineBlockEntity extends PowerAcceptorBlockEntity
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
 		super.tick(world, pos, state, blockEntity);
-		if (world.isClient) {
+		if (world == null || world.isClient) {
 			return;
 		}
 		charge(10);

--- a/src/main/java/techreborn/blockentity/machine/tier3/MatterFabricatorBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/tier3/MatterFabricatorBlockEntity.java
@@ -114,10 +114,10 @@ public class MatterFabricatorBlockEntity extends PowerAcceptorBlockEntity
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
 		super.tick(world, pos, state, blockEntity);
-
-		if (world.isClient) {
+		if (world == null || world.isClient) {
 			return;
 		}
+		
 		this.charge(11);
 
 		for (int i = 0; i < 6; i++) {

--- a/src/main/java/techreborn/blockentity/storage/energy/AdjustableSUBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/energy/AdjustableSUBlockEntity.java
@@ -92,7 +92,7 @@ public class AdjustableSUBlockEntity extends EnergyStorageBlockEntity implements
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
 		super.tick(world, pos, state, blockEntity);
-		if (world == null) {
+		if (world == null || world.isClient) {
 			return;
 		}
 

--- a/src/main/java/techreborn/blockentity/storage/energy/EnergyStorageBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/energy/EnergyStorageBlockEntity.java
@@ -69,12 +69,10 @@ public class EnergyStorageBlockEntity extends PowerAcceptorBlockEntity implement
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
 		super.tick(world, pos, state, blockEntity);
-		if (world == null) {
+		if (world == null || world.isClient) {
 			return;
 		}
-		if (world.isClient) {
-			return;
-		}
+
 		if (!inventory.getStack(0).isEmpty()) {
 			discharge(0);
 		}

--- a/src/main/java/techreborn/blockentity/storage/energy/lesu/LSUStorageBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/energy/lesu/LSUStorageBlockEntity.java
@@ -88,6 +88,10 @@ public class LSUStorageBlockEntity extends MachineBaseBlockEntity
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
 		super.tick(world, pos, state, blockEntity);
+		if (world == null || world.isClient) {
+			return;
+		}
+
 		if (network == null) {
 			findAndJoinNetwork(world, pos);
 		} else {

--- a/src/main/java/techreborn/blockentity/storage/energy/lesu/LapotronicSUBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/energy/lesu/LapotronicSUBlockEntity.java
@@ -101,7 +101,7 @@ public class LapotronicSUBlockEntity extends EnergyStorageBlockEntity implements
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
 		super.tick(world, pos, state, blockEntity);
-		if (world.isClient) {
+		if (world == null || world.isClient) {
 			return;
 		}
 


### PR DESCRIPTION
We've had a couple bugs pop up lately where it was the result of trying to tick on the client side. This patch goes through all the ticking entities (that I could find) and ensures the ordering of calling super.tick and the client-side checks are reasonably consistent.