### PR TITLE
Set creative tank amount to capacity on tick. Fix #2558.

### DIFF
--- a/RebornCore/src/main/java/reborncore/common/fluid/FluidValue.java
+++ b/RebornCore/src/main/java/reborncore/common/fluid/FluidValue.java
@@ -37,7 +37,6 @@ public final class FluidValue {
 	public static final FluidValue EMPTY = new FluidValue(0);
 	public static final FluidValue BUCKET_QUARTER = new FluidValue(FluidConstants.BUCKET / 4);
 	public static final FluidValue BUCKET = new FluidValue(FluidConstants.BUCKET);
-	public static final FluidValue INFINITE = new FluidValue(Long.MAX_VALUE);
 
 	private final long rawValue;
 

--- a/src/main/java/techreborn/blockentity/storage/fluid/TankUnitBaseBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/fluid/TankUnitBaseBlockEntity.java
@@ -100,7 +100,7 @@ public class TankUnitBaseBlockEntity extends MachineBaseBlockEntity implements I
 
 			if (type == TRContent.TankUnit.CREATIVE) {
 				if (!tank.isEmpty() && !tank.isFull()) {
-					tank.setFluidAmount(FluidValue.INFINITE);
+					tank.setFluidAmount(tank.getFluidValueCapacity());
 				}
 			}
 			syncWithAll();

--- a/src/main/java/techreborn/init/TRContent.java
+++ b/src/main/java/techreborn/init/TRContent.java
@@ -309,7 +309,7 @@ public class TRContent {
 		ADVANCED(TechRebornConfig.advancedTankUnitMaxStorage),
 		INDUSTRIAL(TechRebornConfig.industrialTankUnitCapacity),
 		QUANTUM(TechRebornConfig.quantumTankUnitCapacity),
-		CREATIVE(Integer.MAX_VALUE / 1000);
+		CREATIVE(Integer.MAX_VALUE);
 
 		public final String name;
 		public final Block block;

--- a/src/main/java/techreborn/init/TRContent.java
+++ b/src/main/java/techreborn/init/TRContent.java
@@ -309,7 +309,7 @@ public class TRContent {
 		ADVANCED(TechRebornConfig.advancedTankUnitMaxStorage),
 		INDUSTRIAL(TechRebornConfig.industrialTankUnitCapacity),
 		QUANTUM(TechRebornConfig.quantumTankUnitCapacity),
-		CREATIVE(Integer.MAX_VALUE);
+		CREATIVE(Integer.MAX_VALUE / 1000);
 
 		public final String name;
 		public final Block block;


### PR DESCRIPTION
`FluidValue.INFINITE` was higher than the tank's capacity, causing the amount to go higher than the capacity. This would cause insertion to return negative results, which is very bad!