### PR TITLE
Fix cable shape computation. Closes #2435.

### DIFF
--- a/src/main/java/techreborn/blocks/cable/CableBlock.java
+++ b/src/main/java/techreborn/blocks/cable/CableBlock.java
@@ -37,7 +37,6 @@ import net.minecraft.fluid.Fluids;
 import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.particle.ParticleTypes;
-import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.state.StateManager;
@@ -94,7 +93,6 @@ public class CableBlock extends BlockWithEntity implements Waterloggable {
 	});
 
 	public final TRContent.Cables type;
-	private final CableShapeUtil cableShapeUtil;
 
 	public CableBlock(TRContent.Cables type) {
 		super(Block.Settings.of(Material.STONE).strength(1f, 8f));
@@ -102,7 +100,6 @@ public class CableBlock extends BlockWithEntity implements Waterloggable {
 		setDefaultState(this.getStateManager().getDefaultState().with(EAST, false).with(WEST, false).with(NORTH, false)
 				.with(SOUTH, false).with(UP, false).with(DOWN, false).with(WATERLOGGED, false).with(COVERED, false));
 		BlockWrenchEventHandler.wrenableBlocks.add(this);
-		cableShapeUtil = new CableShapeUtil(this);
 	}
 
 	// BlockContainer
@@ -203,7 +200,7 @@ public class CableBlock extends BlockWithEntity implements Waterloggable {
 		if (state.get(COVERED)) {
 			return VoxelShapes.fullCube();
 		}
-		return cableShapeUtil.getShape(state);
+		return CableShapeUtil.getShape(state);
 	}
 
 	@SuppressWarnings("deprecation")

--- a/src/main/java/techreborn/blocks/cable/CableShapeUtil.java
+++ b/src/main/java/techreborn/blocks/cable/CableShapeUtil.java
@@ -26,7 +26,6 @@ package techreborn.blocks.cable;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.util.Util;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;

--- a/src/main/java/techreborn/init/TRContent.java
+++ b/src/main/java/techreborn/init/TRContent.java
@@ -359,7 +359,7 @@ public class TRContent {
 			name = this.toString().toLowerCase(Locale.ROOT);
 			this.transferRate = transferRate;
 			this.defaultTransferRate = transferRate;
-			this.cableThickness = cableThickness / 2;
+			this.cableThickness = cableThickness / 2 / 16;
 			this.canKill = canKill;
 			this.defaultCanKill = canKill;
 			this.tier = tier;


### PR DESCRIPTION
Rewrote the logic. Notably, the shape goes from 0 to 1 and not from 0 to 16. I wouldn't worry about the array allocations: they are only done once per shape, and should easily be optimized away by the JVM.

I moved to a static hashmap to slightly improve startup time, but IIRC vanilla caches shapes inside the BlockState anyway.