### PR TITLE
Fixed missprint into translation of conf direction

### DIFF
--- a/RebornCore/src/main/resources/assets/reborncore/lang/ru_ru.json
+++ b/RebornCore/src/main/resources/assets/reborncore/lang/ru_ru.json
@@ -11,6 +11,7 @@
   "reborncore.tooltip.energy.tier": "Уровень",
   "reborncore.tooltip.energy.change": "Изменение энергии",
   "reborncore.tooltip.energy": "Накопленная энергия",
+  "reborncore.tooltip.has_data": "Сохраненные данные",
 
   "reborncore.gui.heat": "Нагрев",
   "reborncore.gui.missingmultiblock": "Неполный мультиблок",
@@ -34,8 +35,8 @@
   "reborncore.gui.slotconfig.filter_input": "Фильтр ввода",
 
   "reborncore.gui.slotconfigtip.slot": "Выберите слот для настройки.",
-  "reborncore.gui.slotconfigtip.side1": "Оранжевый - вход.",
-  "reborncore.gui.slotconfigtip.side2": "Синий - выход.",
+  "reborncore.gui.slotconfigtip.side1": "Оранжевый - выход.",
+  "reborncore.gui.slotconfigtip.side2": "Синий - вход.",
   "reborncore.gui.slotconfigtip.side3": "Зеленый - вход и выход.",
   "reborncore.gui.slotconfigtip.copy1": "Ctrl+C скопировать настройки.",
   "reborncore.gui.slotconfigtip.copy2": "Ctrl+V вставить настройки.",


### PR DESCRIPTION
Original text is https://github.com/TechReborn/TechReborn/blob/1.17/RebornCore/src/main/resources/assets/reborncore/lang/en_us.json#L38
- "Orange side means output". "Output" is translaited into russian like as "Выход"
Proof: https://translate.google.com/?sl=en&tl=ru&text=output&op=translate

Also added missing translate for key "reborncore.tooltip.has_data"