### PR TITLE
Add missing tags to deepslate ores

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -2,19 +2,31 @@
   "replace": false,
   "values": [
 	"techreborn:bauxite_ore",
+	"techreborn:deepslate_bauxite_ore",
 	"techreborn:cinnabar_ore",
 	"techreborn:galena_ore",
+	"techreborn:deepslate_galena_ore",
 	"techreborn:iridium_ore",
+	"techreborn:deepslate_iridium_ore",
 	"techreborn:lead_ore",
+	"techreborn:deepslate_lead_ore",
 	"techreborn:peridot_ore",
+	"techreborn:deepslate_peridot_ore",
 	"techreborn:pyrite_ore",
 	"techreborn:ruby_ore",
+	"techreborn:deepslate_ruby_ore",
 	"techreborn:sapphire_ore",
+	"techreborn:deepslate_sapphire_ore",
 	"techreborn:sheldonite_ore",
+	"techreborn:deepslate_sheldonite_ore",
 	"techreborn:silver_ore",
+	"techreborn:deepslate_silver_ore",
 	"techreborn:sodalite_ore",
+	"techreborn:deepslate_sodalite_ore",
 	"techreborn:sphalerite_ore",
 	"techreborn:tin_ore",
-	"techreborn:tungsten_ore"
+	"techreborn:deepslate_tin_ore",
+	"techreborn:tungsten_ore",
+	"techreborn:deepslate_tungsten_ore"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/blocks/needs_diamond_tool.json
+++ b/src/main/resources/data/minecraft/tags/blocks/needs_diamond_tool.json
@@ -2,8 +2,12 @@
   "replace": false,
   "values": [
 	"techreborn:iridium_ore",
+	"techreborn:deepslate_iridium_ore",
 	"techreborn:sheldonite_ore",
+	"techreborn:deepslate_sheldonite_ore",
 	"techreborn:sodalite_ore",
-	"techreborn:tungsten_ore"
+	"techreborn:deepslate_sodalite_ore",
+	"techreborn:tungsten_ore",
+	"techreborn:deepslate_tungsten_ore"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/blocks/needs_iron_tool.json
+++ b/src/main/resources/data/minecraft/tags/blocks/needs_iron_tool.json
@@ -2,15 +2,23 @@
   "replace": false,
   "values": [
 	"techreborn:bauxite_ore",
+	"techreborn:deepslate_bauxite_ore",
 	"techreborn:cinnabar_ore",
 	"techreborn:galena_ore",
+	"techreborn:deepslate_galena_ore",
 	"techreborn:lead_ore",
+	"techreborn:deepslate_lead_ore",
 	"techreborn:peridot_ore",
+	"techreborn:deepslate_peridot_ore",
 	"techreborn:pyrite_ore",
 	"techreborn:ruby_ore",
+	"techreborn:deepslate_ruby_ore",
 	"techreborn:sapphire_ore",
+	"techreborn:deepslate_sapphire_ore",
 	"techreborn:silver_ore",
+	"techreborn:deepslate_silver_ore",
 	"techreborn:sphalerite_ore",
-	"techreborn:tin_ore"
+	"techreborn:tin_ore",
+	"techreborn:deepslate_tin_ore"
   ]
 }


### PR DESCRIPTION
Deepslate ores were missing _**mineable/pickaxe**_, _**needs_diamond_tool**_ and _**needs_iron_tool**_ tags.

For example, one of the bugs I encountered due to this is that Drill Items breaks these blocks at wrong speed.