### PR TITLE
TR ores fixes

### DIFF
--- a/src/main/java/techreborn/init/TRContent.java
+++ b/src/main/java/techreborn/init/TRContent.java
@@ -376,43 +376,42 @@ public class TRContent {
 	private final static Map<Ores, Ores> deepslateMap = new HashMap<>();
 
 	public enum Ores implements ItemConvertible {
-		BAUXITE(MiningLevel.IRON, OreDistribution.BAUXITE),
-		CINNABAR(MiningLevel.IRON, OreDistribution.CINNABAR),
-		GALENA(MiningLevel.IRON, OreDistribution.GALENA),
-		IRIDIUM(MiningLevel.DIAMOND, OreDistribution.IRIDIUM),
-		LEAD(MiningLevel.IRON, OreDistribution.LEAD),
-		PERIDOT(MiningLevel.DIAMOND, OreDistribution.PERIDOT),
-		PYRITE(MiningLevel.DIAMOND, OreDistribution.PYRITE),
-		RUBY(MiningLevel.IRON, OreDistribution.RUBY),
-		SAPPHIRE(MiningLevel.IRON, OreDistribution.SAPPHIRE),
-		SHELDONITE(MiningLevel.DIAMOND, OreDistribution.SHELDONITE),
-		SILVER(MiningLevel.IRON, OreDistribution.SILVER),
-		SODALITE(MiningLevel.DIAMOND, OreDistribution.SODALITE),
-		SPHALERITE(MiningLevel.IRON, OreDistribution.SPHALERITE),
-		TIN(MiningLevel.STONE, OreDistribution.TIN),
-		TUNGSTEN(MiningLevel.DIAMOND, OreDistribution.TUNGSTEN),
+		BAUXITE(OreDistribution.BAUXITE),
+		CINNABAR(OreDistribution.CINNABAR),
+		GALENA(OreDistribution.GALENA),
+		IRIDIUM(OreDistribution.IRIDIUM),
+		LEAD(OreDistribution.LEAD),
+		PERIDOT(OreDistribution.PERIDOT),
+		PYRITE(OreDistribution.PYRITE),
+		RUBY(OreDistribution.RUBY),
+		SAPPHIRE(OreDistribution.SAPPHIRE),
+		SHELDONITE(OreDistribution.SHELDONITE),
+		SILVER(OreDistribution.SILVER),
+		SODALITE(OreDistribution.SODALITE),
+		SPHALERITE(OreDistribution.SPHALERITE),
+		TIN(OreDistribution.TIN),
+		TUNGSTEN(OreDistribution.TUNGSTEN),
 
-		DEEPSLATE_BAUXITE(BAUXITE, MiningLevel.IRON),
-		DEEPSLATE_GALENA(GALENA, MiningLevel.IRON),
-		DEEPSLATE_IRIDIUM(IRIDIUM, MiningLevel.DIAMOND),
-		DEEPSLATE_LEAD(LEAD, MiningLevel.IRON),
-		DEEPSLATE_PERIDOT(PERIDOT, MiningLevel.DIAMOND),
-		DEEPSLATE_RUBY(RUBY, MiningLevel.IRON),
-		DEEPSLATE_SAPPHIRE(SAPPHIRE, MiningLevel.IRON),
-		DEEPSLATE_SHELDONITE(SHELDONITE, MiningLevel.DIAMOND),
-		DEEPSLATE_SILVER(SILVER, MiningLevel.IRON),
-		DEEPSLATE_SODALITE(SODALITE, MiningLevel.DIAMOND),
-		DEEPSLATE_TIN(TIN, MiningLevel.STONE),
-		DEEPSLATE_TUNGSTEN(TUNGSTEN, MiningLevel.DIAMOND);
+		DEEPSLATE_BAUXITE(BAUXITE),
+		DEEPSLATE_GALENA(GALENA),
+		DEEPSLATE_IRIDIUM(IRIDIUM),
+		DEEPSLATE_LEAD(LEAD),
+		DEEPSLATE_PERIDOT(PERIDOT),
+		DEEPSLATE_RUBY(RUBY),
+		DEEPSLATE_SAPPHIRE(SAPPHIRE),
+		DEEPSLATE_SHELDONITE(SHELDONITE),
+		DEEPSLATE_SILVER(SILVER),
+		DEEPSLATE_SODALITE(SODALITE),
+		DEEPSLATE_TIN(TIN),
+		DEEPSLATE_TUNGSTEN(TUNGSTEN);
 
 		public final String name;
 		public final Block block;
 		public final OreDistribution distribution;
 
-		Ores(MiningLevel miningLevel, OreDistribution distribution) {
+		Ores(OreDistribution distribution) {
 			name = this.toString().toLowerCase(Locale.ROOT);
 			block = new OreBlock(FabricBlockSettings.of(Material.STONE)
-					.breakByTool(FabricToolTags.PICKAXES, miningLevel.intLevel)
 					.requiresTool()
 					.sounds(BlockSoundGroup.STONE)
 					.strength(2f, 2f)
@@ -422,8 +421,8 @@ public class TRContent {
 			this.distribution = distribution;
 		}
 
-		Ores(TRContent.Ores stoneOre, MiningLevel miningLevel) {
-			this(miningLevel, null);
+		Ores(TRContent.Ores stoneOre) {
+			this((OreDistribution) null);
 			deepslateMap.put(stoneOre, this);
 		}
 

--- a/src/main/java/techreborn/init/TRContent.java
+++ b/src/main/java/techreborn/init/TRContent.java
@@ -26,7 +26,6 @@ package techreborn.init;
 
 import com.google.common.base.Preconditions;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
-import net.fabricmc.fabric.api.tool.attribute.v1.FabricToolTags;
 import net.minecraft.block.*;
 import net.minecraft.entity.EntityType;
 import net.minecraft.item.Item;
@@ -80,7 +79,6 @@ import techreborn.entities.EntityNukePrimed;
 import techreborn.items.DynamicCellItem;
 import techreborn.items.UpgradeItem;
 import techreborn.items.armor.QuantumSuitItem;
-import techreborn.items.tool.MiningLevel;
 import techreborn.utils.InitUtils;
 import techreborn.world.OreDistribution;
 

--- a/src/main/java/techreborn/init/TRContent.java
+++ b/src/main/java/techreborn/init/TRContent.java
@@ -411,7 +411,7 @@ public class TRContent {
 			name = this.toString().toLowerCase(Locale.ROOT);
 			block = new OreBlock(FabricBlockSettings.of(Material.STONE)
 					.requiresTool()
-					.sounds(BlockSoundGroup.STONE)
+					.sounds(name.startsWith("deepslate") ? BlockSoundGroup.DEEPSLATE : BlockSoundGroup.STONE)
 					.strength(2f, 2f)
 			);
 

--- a/src/main/resources/data/minecraft/tags/blocks/needs_iron_tool.json
+++ b/src/main/resources/data/minecraft/tags/blocks/needs_iron_tool.json
@@ -17,8 +17,6 @@
 	"techreborn:deepslate_sapphire_ore",
 	"techreborn:silver_ore",
 	"techreborn:deepslate_silver_ore",
-	"techreborn:sphalerite_ore",
-	"techreborn:tin_ore",
-	"techreborn:deepslate_tin_ore"
+	"techreborn:sphalerite_ore"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/blocks/needs_stone_tool.json
+++ b/src/main/resources/data/minecraft/tags/blocks/needs_stone_tool.json
@@ -1,0 +1,7 @@
+{
+    "replace": false,
+    "values": [
+        "techreborn:tin_ore",
+        "techreborn:deepslate_tin_ore"
+    ]
+}


### PR DESCRIPTION
There are three changes in this PR.

**- Removed deprecated function breaksByTool():** 

Since Minecraft 1.17 to define harvest tools and harvest levels we need to use tags, so I refactored the code to remove hardcoded mining levels and tool requirements, which were already defined in tags.
This function was causing the ores to be able to be broken with any tool.
This change fixes and closes #2609 (thanks to @xanthian for clues on what was causing this bug)


**- Changed BlockSoundGroup for Deepslate ores:**

Deepslate ores have a different sound group, Now TR deepslate ores sound correctly.


**- Fix Tin Ore mining tool requirement tag:**

It was hardcoded that tin tool requirement was stone, but it was on iron tool tag, so I've changed it to stone like it was hardcoded before refactoring the code.