### PR TITLE
Added tooltips for unobtainable ores.

### DIFF
--- a/src/main/java/techreborn/init/TRContent.java
+++ b/src/main/java/techreborn/init/TRContent.java
@@ -381,6 +381,8 @@ public class TRContent {
 
 	private final static Map<Ores, Ores> deepslateMap = new HashMap<>();
 
+	private final static Map<Ores, Ores> unDeepslateMap = new HashMap<>();
+
 	public enum Ores implements ItemConvertible {
 		// when changing ores also change data/techreborn/tags/items/ores.json for correct root advancement display
 		// as well as data/minecraft/tags/blocks for correct mining level
@@ -432,6 +434,7 @@ public class TRContent {
 		Ores(TRContent.Ores stoneOre) {
 			this((OreDistribution) null);
 			deepslateMap.put(stoneOre, this);
+			unDeepslateMap.put(this, stoneOre);
 		}
 
 		@Override
@@ -442,6 +445,11 @@ public class TRContent {
 		public TRContent.Ores getDeepslate() {
 			Preconditions.checkArgument(!isDeepslate());
 			return deepslateMap.get(this);
+		}
+
+		public TRContent.Ores getUnDeepslate() {
+			Preconditions.checkArgument(isDeepslate());
+			return unDeepslateMap.get(this);
 		}
 
 		public boolean isDeepslate() {

--- a/src/main/resources/assets/techreborn/lang/en_us.json
+++ b/src/main/resources/assets/techreborn/lang/en_us.json
@@ -875,6 +875,7 @@
   "techreborn.tooltip.ores.overworld" : "Can be found at y levels %s < %s",
   "techreborn.tooltip.ores.nether" : "Can be found in the nether",
   "techreborn.tooltip.ores.end" : "Can be found in the end",
+  "techreborn.tooltip.unobtainable": "Unobtainable in Survival Mode",
 
   "_comment23": "ManualUI",
   "techreborn.manual.wiki": "Online wiki",


### PR DESCRIPTION
This was a bit tricky. There were three possibilities: replace the deepslate map with a BiMap (which wasn't giving me a suitable implementation), filter by correct value, put resulting keys into list, take first one (no permanent space, but timey operation every time hovered over an ore) or do a second map that has to be updated analogously (little extra permanent space, fast, but least maintainable).

I opted for the fast option in the hope future contributers will look how either map is used if they want to use them and then see the other one. Should only happen if they meddle with TR.Content.Ores code, so the maintenance increase is pretty small after all, too. Isn't even dependent on the 4 ores in question, but will work for any non-overworld-dimension deepslate for now.

Ah, and the main reason I had to go that deep into code editing in the first place is because I couldn't get the enum value from the item, or use instanceof or anything like that.