### PR TITLE
Greenhouse Controller UI Texture bugfix

### DIFF
--- a/src/main/java/techreborn/client/gui/GuiGreenhouseController.java
+++ b/src/main/java/techreborn/client/gui/GuiGreenhouseController.java
@@ -24,6 +24,7 @@
 
 package techreborn.client.gui;
 
+import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.player.PlayerEntity;
@@ -64,7 +65,7 @@ public class GuiGreenhouseController extends GuiBase<BuiltScreenHandler> {
 		drawSlot(matrixStack, 48, gridYPos + 36, layer);
 
 		if (!blockEntity.isMultiblockValid()) {
-			getMinecraft().getTextureManager().bindTexture(new Identifier("techreborn", "textures/item/part/digital_display.png"));
+			RenderSystem.setShaderTexture(0, new Identifier("techreborn", "textures/item/part/digital_display.png"));
 			drawTexture(matrixStack, x + 68, y + 22, 0, 0, 16, 16, 16, 16);
 			if (isPointInRect(68, 22, 16, 16, mouseX, mouseY)) {
 				List<Text> list = Arrays.stream(I18n.translate("techreborn.tooltip.greenhouse.upgrade_available")


### PR DESCRIPTION
A button texture wouldn't be bound correctly works as I think it was intended
**Before**
![not working](https://user-images.githubusercontent.com/26858961/146695516-0e2ba8ca-974d-4b87-ada6-46972107064c.png)
**After**
![working](https://user-images.githubusercontent.com/26858961/146695523-2b6e9da6-a7bb-4f23-b66e-e3796148dd17.png)
