### PR TITLE
Extractor: Fixed Sunflower and added Wither Rose.

### DIFF
--- a/src/main/resources/data/techreborn/recipes/extractor/black_dye_from_wither_rose.json
+++ b/src/main/resources/data/techreborn/recipes/extractor/black_dye_from_wither_rose.json
@@ -4,13 +4,13 @@
   "time": 300,
   "ingredients": [
     {
-      "item": "minecraft:sunflower"
+      "item": "minecraft:wither_rose"
     }
   ],
   "results": [
     {
-      "item": "minecraft:yellow_dye",
-      "count": 4
+      "item": "minecraft:black_dye",
+      "count": 2
     }
   ]
 }


### PR DESCRIPTION
Sunflower gives 2 dyes normally in-game and the extractor usually doubles the amount, so sunflower giving 2 dyes in Extractor was a bug. Also added dye from Wither Rose (gives 1 dye normally, so here 2).