### PR TITLE
Vacuum Freezer: Added Blue Ice

### DIFF
--- a/src/main/resources/data/techreborn/recipes/vacuum_freezer/blue_ice.json
+++ b/src/main/resources/data/techreborn/recipes/vacuum_freezer/blue_ice.json
@@ -1,0 +1,16 @@
+{
+  "type": "techreborn:vacuum_freezer",
+  "power": 60,
+  "time": 64,
+  "ingredients": [
+    {
+      "item": "minecraft:packed_ice",
+      "count": 4
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:blue_ice"
+    }
+  ]
+}


### PR DESCRIPTION
Because why not? 2 Ice are needed to vacuum freeze into 1 Packed Ice, and since Blue Ice is more sought out, I thought 4 Packed Ice into 1 Blue Ice for same energy is fair. This means instead of 81 Ice blocks to make 1 Blue Ice with TR only 8 are needed, about -90% for a task that usually takes extreme amounts of grinding/afk. Without the new recipe it would be 18 Ice Blocks, so about -80%.

Other balancing could be done with power or time, but I am not well versed enough in these to balance them right.