### PR TITLE
Final commit to resolve #2675 I hope

### DIFF
--- a/src/main/java/techreborn/items/DynamicCellItem.java
+++ b/src/main/java/techreborn/items/DynamicCellItem.java
@@ -171,7 +171,7 @@ public class DynamicCellItem extends Item implements ItemFluidInfo {
 		Fluid containedFluid = getFluid(stack);
 
 		BlockHitResult hitResult = raycast(world, player, containedFluid == Fluids.EMPTY ? RaycastContext.FluidHandling.SOURCE_ONLY : RaycastContext.FluidHandling.NONE);
-		if (hitResult.getType() == HitResult.Type.MISS || !(containedFluid instanceof FlowableFluid)) {
+			if (hitResult.getType() == HitResult.Type.MISS || !(containedFluid instanceof FlowableFluid || Fluids.EMPTY == containedFluid)) {
 			return TypedActionResult.pass(stack);
 		}
 		if (hitResult.getType() != HitResult.Type.BLOCK) {
@@ -207,8 +207,6 @@ public class DynamicCellItem extends Item implements ItemFluidInfo {
 				return TypedActionResult.success(resultStack, world.isClient());
 			}
 		} else {
-			if (!(containedFluid instanceof FlowableFluid))
-				return TypedActionResult.pass(stack);
 			BlockState placeState = world.getBlockState(placePos);
 			if (placeState.canBucketPlace(containedFluid)) {
 				placeFluid(player, world, placePos, hitResult, stack);


### PR DESCRIPTION
Bug history: Cells were able to put out fluids which are not FlowableFluids, causing a textureless block to appear. First commit checked for FlowableFluid necessary in cell item to do anything with it. However since EMPTY is not a FlowableFluid that led to Cells being unable to pick up fluids any longer. Second commit attempted to fix but didn't because I checked it wrongly (tested with buckets instead of cells). In fact it doesn't do anything (because the same check was performed earlier), so I reverted it with this commit. And finally this commit adds EMPTY as an acceptable fluid inside a cell to do something with it.