### PR TITLE
Added tooltip for unplaceable fluids in cells.

### DIFF
--- a/src/main/java/techreborn/events/StackToolTipHandler.java
+++ b/src/main/java/techreborn/events/StackToolTipHandler.java
@@ -31,6 +31,9 @@ import net.minecraft.block.Block;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.item.TooltipContext;
+import net.minecraft.fluid.FlowableFluid;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.Fluids;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.integrated.IntegratedServer;
@@ -45,6 +48,7 @@ import net.minecraft.world.gen.HeightContext;
 import org.jetbrains.annotations.Nullable;
 import reborncore.common.BaseBlockEntityProvider;
 import techreborn.init.TRContent;
+import techreborn.items.DynamicCellItem;
 import techreborn.items.UpgradeItem;
 import techreborn.utils.ToolTipAssistUtils;
 import techreborn.world.OreDistribution;
@@ -108,6 +112,12 @@ public class StackToolTipHandler implements ItemTooltipCallback {
 		if (item instanceof UpgradeItem upgrade) {
 			ToolTipAssistUtils.addInfo(item.getTranslationKey(), tooltipLines, false);
 			tooltipLines.addAll(ToolTipAssistUtils.getUpgradeStats(TRContent.Upgrades.valueOf(upgrade.name.toUpperCase()), stack.getCount(), Screen.hasShiftDown()));
+		}
+
+		if (item instanceof DynamicCellItem cell) {
+			Fluid fluid = cell.getFluid(stack);
+			if (!(fluid instanceof FlowableFluid) && fluid != Fluids.EMPTY)
+				ToolTipAssistUtils.addInfo("unplaceable_fluid", tooltipLines, false);
 		}
 
 		Text text = null;

--- a/src/main/resources/assets/techreborn/lang/en_us.json
+++ b/src/main/resources/assets/techreborn/lang/en_us.json
@@ -752,6 +752,8 @@
   "techreborn.message.info.item.techreborn.energy_storage_upgrade": "Increase energy store",
   "techreborn.message.info.item.techreborn.superconductor_upgrade": "Increases energy flow rate",
 
+  "techreborn.message.info.unplaceable_fluid": "Cannot be placed",
+
   "techreborn.message.info.block.techreborn.basic_solar_panel": "Produce energy from sunlight",
   "techreborn.message.info.block.techreborn.advanced_solar_panel": "Produce energy from sunlight",
   "techreborn.message.info.block.techreborn.industrial_solar_panel": "Produce energy from sunlight",


### PR DESCRIPTION
Only cells, not buckets, yes. Because TR only creates cells from other mods' fluids, not buckets. If the other mods' buckets are not placeable, people will complain to the appropriate mod. But if they only use cells and some "TR" cells are not placeable without any indication they will come to us. This tooltip will hopefully keep them from doing that.