### PR TITLE
Deleted empty columns

### DIFF
--- a/src/main/resources/data/techreborn/recipes/crafting_table/machine/hv_transformer.json
+++ b/src/main/resources/data/techreborn/recipes/crafting_table/machine/hv_transformer.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    " H ",
-    " M ",
-    " H "
+    "H",
+    "M",
+    "H"
   ],
   "key": {
     "H": {


### PR DESCRIPTION
Unneccessary empty columns in HV transformer recipe