### PR TITLE
Changed the number of plates back to 9

### DIFF
--- a/src/main/resources/data/techreborn/recipes/compressor/lapis_plate_from_block.json
+++ b/src/main/resources/data/techreborn/recipes/compressor/lapis_plate_from_block.json
@@ -10,7 +10,7 @@
   "results": [
     {
       "item": "techreborn:lapis_plate",
-      "count": 1
+      "count": 9
     }
   ]
 }


### PR DESCRIPTION
maybe it was an attempt of making lapotronic stuff more expensive/balanced, but you could still get a plate from one lapis dust and changing that now out of nowhere would probably confuse/upset many players. Hence correction of this recipe for easier use