### PR TITLE
Added 2 blaze powder related recipes

### DIFF
--- a/src/main/resources/data/techreborn/recipes/compressor/blaze_rod.json
+++ b/src/main/resources/data/techreborn/recipes/compressor/blaze_rod.json
@@ -1,0 +1,16 @@
+{
+  "type": "techreborn:compressor",
+  "power": 10,
+  "time": 300,
+  "ingredients": [
+    {
+      "item": "minecraft:blaze_powder",
+      "count": 5
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:blaze_rod"
+    }
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/industrial_grinder/magma_block_with_water.json
+++ b/src/main/resources/data/techreborn/recipes/industrial_grinder/magma_block_with_water.json
@@ -1,0 +1,25 @@
+{
+    "type": "techreborn:industrial_grinder",
+    "power": 64,
+    "time": 250,
+    "tank": {
+        "fluid": "minecraft:water",
+        "amount": 2000
+    },
+    "ingredients": [
+        {
+            "item": "minecraft:magma_block",
+		  	"count": 5
+        }
+    ],
+    "results": [
+        {
+            "item": "techreborn:obsidian_dust",
+            "count": 4
+        },
+        {
+            "item": "minecraft:magma_cream",
+            "count": 1
+        }
+    ]
+}


### PR DESCRIPTION
1 Blaze Rod gets grinded into 4 powders already, so compressing 5 powders into 1 rod shouldn't be a problem. The Ind Centrifuge magma block recipe is more interesting. Double normal water amount because half of that is used to cool the remains of the magma block down afterwards, the other half for usual centrifuge recipe. Magma is relatively soft, so one magma block only needs half as much time as an ore, but we have 5 to grind, so 2.5 that time amount, leading to a time of 250. Only one Magma Cream gets produced. 2 are needed to centrifuge to blaze powder, so 10 Magma blocks. Hence 120 Magma blocks or about 2 stacks to get enough blaze powder to create 12 Ender Eyes, or just half of that (1 stack) if chemical reactor is used. Sounds balanced to me.