### PR TITLE
Added drills and omnitool to full-amethyst-harvesters

### DIFF
--- a/src/main/resources/data/minecraft/tags/items/cluster_max_harvestables.json
+++ b/src/main/resources/data/minecraft/tags/items/cluster_max_harvestables.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "techreborn:basic_drill",
+	"techreborn:advanced_drill",
+	"techreborn:industrial_drill",
+	"techreborn:omni_tool"
+  ]
+}


### PR DESCRIPTION
Minecraft tags indicate that iron pickaxe and above always yield 4 amethyst shards when used on a maxed out cluster. Therefore added drills and omnitool, which is part drill. Since jackhammer doesn't mine ores usually it felt right to leave it out of this too.