### PR TITLE
Added recipes related to nether fungus

### DIFF
--- a/src/main/resources/data/techreborn/recipes/centrifuge/crimson_nylium.json
+++ b/src/main/resources/data/techreborn/recipes/centrifuge/crimson_nylium.json
@@ -1,0 +1,21 @@
+{
+  "type": "techreborn:centrifuge",
+  "power": 5,
+  "time": 1640,
+  "ingredients": [
+    {
+      "item": "minecraft:crimson_nylium",
+      "count": 8
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:netherrack",
+      "count": 6
+    },
+    {
+      "item": "minecraft:crimson_fungus",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/centrifuge/nether_wart_block.json
+++ b/src/main/resources/data/techreborn/recipes/centrifuge/nether_wart_block.json
@@ -1,0 +1,23 @@
+{
+  "type": "techreborn:centrifuge",
+  "power": 5,
+  "time": 5000,
+  "ingredients": [
+    {
+      "item": "minecraft:nether_wart_block",
+      "count": 12
+    },
+    {
+      "item": "techreborn:cell",
+      "nbt": "null"
+    }
+  ],
+  "results": [
+    {
+      "item": "techreborn:cell",
+      "nbt": {
+        "fluid": "techreborn:methane"
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/centrifuge/shroomlight.json
+++ b/src/main/resources/data/techreborn/recipes/centrifuge/shroomlight.json
@@ -1,0 +1,27 @@
+{
+  "type": "techreborn:centrifuge",
+  "power": 5,
+  "time": 5000,
+  "ingredients": [
+    {
+      "item": "minecraft:shroomlight",
+      "count": 8
+    },
+    {
+      "item": "techreborn:cell",
+      "nbt": "null"
+    }
+  ],
+  "results": [
+    {
+      "item": "techreborn:cell",
+      "nbt": {
+        "fluid": "techreborn:methane"
+      }
+    },
+	{
+	  "item": "minecraft:glowstone_dust",
+	  "count": 4
+	}
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/centrifuge/warped_nylium.json
+++ b/src/main/resources/data/techreborn/recipes/centrifuge/warped_nylium.json
@@ -1,0 +1,21 @@
+{
+  "type": "techreborn:centrifuge",
+  "power": 5,
+  "time": 1640,
+  "ingredients": [
+    {
+      "item": "minecraft:warped_nylium",
+      "count": 8
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:netherrack",
+      "count": 6
+    },
+    {
+      "item": "minecraft:warped_fungus",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/centrifuge/warped_wart_block.json
+++ b/src/main/resources/data/techreborn/recipes/centrifuge/warped_wart_block.json
@@ -1,0 +1,27 @@
+{
+  "type": "techreborn:centrifuge",
+  "power": 5,
+  "time": 5000,
+  "ingredients": [
+    {
+      "item": "minecraft:warped_wart_block",
+      "count": 12
+    },
+    {
+      "item": "techreborn:cell",
+      "nbt": "null"
+    }
+  ],
+  "results": [
+    {
+      "item": "techreborn:cell",
+      "nbt": {
+        "fluid": "techreborn:methane"
+      }
+    },
+	{
+	  "item": "techreborn:ender_pearl_dust",
+	  "count": 2
+	}
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/shroomlight_from_brown.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/shroomlight_from_brown.json
@@ -1,0 +1,19 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 400,
+	"ingredients": [
+		{
+			"item": "minecraft:glowstone_dust",
+			"count": 4
+		},
+		{
+			"item": "minecraft:brown_mushroom_block"
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:shroomlight"
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/shroomlight_from_crimson.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/shroomlight_from_crimson.json
@@ -1,0 +1,19 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 400,
+	"ingredients": [
+		{
+			"item": "minecraft:glowstone_dust",
+			"count": 4
+		},
+		{
+			"item": "minecraft:nether_wart_block"
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:shroomlight"
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/shroomlight_from_red.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/shroomlight_from_red.json
@@ -1,0 +1,19 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 400,
+	"ingredients": [
+		{
+			"item": "minecraft:glowstone_dust",
+			"count": 4
+		},
+		{
+			"item": "minecraft:red_mushroom_block"
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:shroomlight"
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/shroomlight_from_warped.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/shroomlight_from_warped.json
@@ -1,0 +1,19 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 400,
+	"ingredients": [
+		{
+			"item": "minecraft:glowstone_dust",
+			"count": 4
+		},
+		{
+			"item": "minecraft:warped_wart_block"
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:shroomlight"
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/stripped_warped_hyphae.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/stripped_warped_hyphae.json
@@ -1,0 +1,19 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 500,
+	"ingredients": [
+		{
+			"item": "minecraft:stripped_crimson_hyphae"
+		},
+		{
+			"tag": "c:ender_pearl_dusts",
+			"count": 2
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:stripped_warped_hyphae"
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/stripped_warped_stem.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/stripped_warped_stem.json
@@ -1,0 +1,19 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 500,
+	"ingredients": [
+		{
+			"item": "minecraft:stripped_crimson_stem"
+		},
+		{
+			"tag": "c:ender_pearl_dusts",
+			"count": 2
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:stripped_warped_stem"
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_button.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_button.json
@@ -1,0 +1,20 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 400,
+	"ingredients": [
+		{
+			"item": "minecraft:crimson_button",
+			"count": 2
+		},
+		{
+			"tag": "c:ender_pearl_dusts"
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:warped_button",
+			"count": 2
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_door.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_door.json
@@ -1,0 +1,20 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 400,
+	"ingredients": [
+		{
+			"item": "minecraft:crimson_door",
+			"count": 2
+		},
+		{
+			"tag": "c:ender_pearl_dusts"
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:warped_door",
+			"count": 2
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_fence.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_fence.json
@@ -1,0 +1,21 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 500,
+	"ingredients": [
+		{
+			"item": "minecraft:crimson_fence",
+			"count": 3
+		},
+		{
+			"tag": "c:ender_pearl_dusts",
+			"count": 2
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:warped_fence",
+			"count": 3
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_fence_gate.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_fence_gate.json
@@ -1,0 +1,20 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 400,
+	"ingredients": [
+		{
+			"item": "minecraft:crimson_fence_gate",
+			"count": 2
+		},
+		{
+			"tag": "c:ender_pearl_dusts"
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:warped_fence_gate",
+			"count": 2
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_hyphae.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_hyphae.json
@@ -1,0 +1,19 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 500,
+	"ingredients": [
+		{
+			"item": "minecraft:crimson_hyphae"
+		},
+		{
+			"tag": "c:ender_pearl_dusts",
+			"count": 2
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:warped_hyphae"
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_planks.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_planks.json
@@ -1,0 +1,20 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 400,
+	"ingredients": [
+		{
+			"item": "minecraft:crimson_planks",
+			"count": 2
+		},
+		{
+			"tag": "c:ender_pearl_dusts"
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:warped_planks",
+			"count": 2
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_pressure_plate.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_pressure_plate.json
@@ -1,0 +1,18 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 400,
+	"ingredients": [
+		{
+			"item": "minecraft:crimson_pressure_plate"
+		},
+		{
+			"tag": "c:ender_pearl_dusts"
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:warped_pressure_plate"
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_sign.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_sign.json
@@ -1,0 +1,18 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 400,
+	"ingredients": [
+		{
+			"item": "minecraft:crimson_sign"
+		},
+		{
+			"tag": "c:ender_pearl_dusts"
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:warped_sign"
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_slab.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_slab.json
@@ -1,0 +1,20 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 400,
+	"ingredients": [
+		{
+			"item": "minecraft:crimson_slab",
+			"count": 4
+		},
+		{
+			"tag": "c:ender_pearl_dusts"
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:warped_slab",
+			"count": 4
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_stairs.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_stairs.json
@@ -1,0 +1,21 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 600,
+	"ingredients": [
+		{
+			"item": "minecraft:crimson_stairs",
+			"count": 4
+		},
+		{
+			"tag": "c:ender_pearl_dusts",
+			"count": 3
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:warped_stairs",
+			"count": 4
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_stem.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_stem.json
@@ -1,0 +1,19 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 500,
+	"ingredients": [
+		{
+			"item": "minecraft:crimson_stem"
+		},
+		{
+			"tag": "c:ender_pearl_dusts",
+			"count": 2
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:warped_stem"
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_trapdoor.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_trapdoor.json
@@ -1,0 +1,21 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 600,
+	"ingredients": [
+		{
+			"item": "minecraft:crimson_trapdoor",
+			"count": 2
+		},
+		{
+			"tag": "c:ender_pearl_dusts",
+			"count": 3
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:warped_trapdoor",
+			"count": 2
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_wart_block.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/warped_wart_block.json
@@ -1,0 +1,19 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 500,
+	"ingredients": [
+		{
+			"item": "minecraft:nether_wart_block"
+		},
+		{
+			"tag": "c:ender_pearl_dusts",
+			"count": 2
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:warped_wart_block"
+		}
+	]
+}

--- a/src/main/resources/data/techreborn/recipes/grinder/netherrack_dust_from_crimson.json
+++ b/src/main/resources/data/techreborn/recipes/grinder/netherrack_dust_from_crimson.json
@@ -1,0 +1,15 @@
+{
+  "type": "techreborn:grinder",
+  "power": 4,
+  "time": 200,
+  "ingredients" : [
+    {
+      "item": "minecraft:crimson_nylium"
+    }
+  ],
+  "results" : [
+    {
+      "item": "techreborn:netherrack_dust"
+    }
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/grinder/netherrack_dust_from_warped.json
+++ b/src/main/resources/data/techreborn/recipes/grinder/netherrack_dust_from_warped.json
@@ -1,0 +1,15 @@
+{
+  "type": "techreborn:grinder",
+  "power": 4,
+  "time": 200,
+  "ingredients" : [
+    {
+      "item": "minecraft:warped_nylium"
+    }
+  ],
+  "results" : [
+    {
+      "item": "techreborn:netherrack_dust"
+    }
+  ]
+}


### PR DESCRIPTION
Balancing notes: 1 ender pearl dust can infuse 2 planks, leading to all the warped infusion recipes. Shroomlights should at least take as much glowstone dust as normal glowstone, hence 4. On the other hand, 2 Shroomlights giving 1 glowstone dust when centrifuged is a bit stingy, but we also have to take into account the methane, which we need only 8 blocks for, because shroomlights are less common than the wart blocks. Wart blocks were copied from mushroom blocks. Nylium was inspired by mycelium, but a bit changed with netherrack dust in mind.

Ah, and mushroom stems cannot be used to create shroomlights, because that would mean crimson/warped stems could be used too. I wanted to avoid that, since nether stems are more like wood than like mushroom blocks.