### PR TITLE
Added wither skeleton skull recipe

### DIFF
--- a/src/main/resources/data/techreborn/recipes/chemical_reactor/wither_skeleton_skull.json
+++ b/src/main/resources/data/techreborn/recipes/chemical_reactor/wither_skeleton_skull.json
@@ -1,0 +1,19 @@
+{
+	"type": "techreborn:chemical_reactor",
+	"power": 30,
+	"time": 400,
+	"ingredients": [
+		{
+			"item": "minecraft:wither_rose",
+			"count": 8
+		},
+		{
+			"item": "minecraft:skeleton_skull"
+		}
+	],
+	"results": [
+		{
+			"item": "minecraft:wither_skeleton_skull"
+		}
+	]
+}


### PR DESCRIPTION
Since skeleton skulls are not too easy to come by either and wither roses are usually locked behind the first wither summon, this seems balanced.

Tested by Xanthian.