### PR TITLE
Make energy tools usable while charging, fixes #2232

### DIFF
--- a/RebornCore/src/main/java/reborncore/common/powerSystem/RcEnergyItem.java
+++ b/RebornCore/src/main/java/reborncore/common/powerSystem/RcEnergyItem.java
@@ -1,5 +1,10 @@
 package reborncore.common.powerSystem;
 
+import net.fabricmc.fabric.api.item.v1.FabricItem;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
+import reborncore.common.util.ItemUtils;
 import team.reborn.energy.api.base.SimpleBatteryItem;
 
 /**
@@ -10,7 +15,7 @@ import team.reborn.energy.api.base.SimpleBatteryItem;
  * </ul>
  * TODO: consider moving this functionality to the energy API?
  */
-public interface RcEnergyItem extends SimpleBatteryItem {
+public interface RcEnergyItem extends SimpleBatteryItem, FabricItem {
 	long getEnergyCapacity();
 
 	/**
@@ -24,5 +29,15 @@ public interface RcEnergyItem extends SimpleBatteryItem {
 
 	default long getEnergyMaxOutput() {
 		return getTier().getMaxOutput();
+	}
+
+	@Override
+	default boolean allowNbtUpdateAnimation(PlayerEntity player, Hand hand, ItemStack oldStack, ItemStack newStack) {
+		return !ItemUtils.isEqualIgnoreEnergy(oldStack, newStack);
+	}
+
+	@Override
+	default boolean allowContinuingBlockBreaking(PlayerEntity player, ItemStack oldStack, ItemStack newStack) {
+		return ItemUtils.isEqualIgnoreEnergy(oldStack, newStack);
 	}
 }

--- a/RebornCore/src/main/java/reborncore/common/util/ItemUtils.java
+++ b/RebornCore/src/main/java/reborncore/common/util/ItemUtils.java
@@ -38,6 +38,7 @@ import reborncore.common.powerSystem.RcEnergyItem;
 import reborncore.common.recipes.IRecipeInput;
 import team.reborn.energy.api.EnergyStorage;
 import team.reborn.energy.api.EnergyStorageUtil;
+import team.reborn.energy.api.base.SimpleBatteryItem;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -74,6 +75,29 @@ public class ItemUtils {
 			//TODO tags
 		}
 		return false;
+	}
+
+	public static boolean isEqualIgnoreEnergy(ItemStack stack1, ItemStack stack2) {
+		if (stack1 == stack2) {
+			return true;
+		}
+		if (!stack1.isOf(stack2.getItem())) {
+			return false;
+		}
+		if (stack1.getCount() != stack2.getCount()) {
+			return false;
+		}
+		if (stack1.getNbt() == stack2.getNbt()) {
+			return true;
+		}
+		if (stack1.getNbt() == null || stack2.getNbt() == null) {
+			return false;
+		}
+		NbtCompound nbt1Copy = stack1.getNbt().copy();
+		NbtCompound nbt2Copy = stack2.getNbt().copy();
+		nbt1Copy.remove(SimpleBatteryItem.ENERGY_KEY);
+		nbt2Copy.remove(SimpleBatteryItem.ENERGY_KEY);
+		return nbt1Copy.equals(nbt2Copy);
 	}
 
 	//TODO tags


### PR DESCRIPTION
Used Fabric API features to prevent constant block breaking canceling while ItemStack in hand charges.
Fix for #2232 and closed #2370 

Before: https://youtu.be/TUTQsJ36TdQ
After: https://youtu.be/ej2ADwSasrk