### PR TITLE
Added misc recipes

### DIFF
--- a/src/main/resources/data/c/tags/items/grass_variants.json
+++ b/src/main/resources/data/c/tags/items/grass_variants.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+	"minecraft:grass",
+	"minecraft:tall_grass",
+	"minecraft:fern",
+	"minecraft:large_fern",
+	"minecraft:moss_carpet",
+	"minecraft:seagrass"
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/centrifuge/egg.json
+++ b/src/main/resources/data/techreborn/recipes/centrifuge/egg.json
@@ -1,0 +1,26 @@
+{
+  "type": "techreborn:centrifuge",
+  "power": 5,
+  "time": 5000,
+  "ingredients": [
+    {
+      "item": "minecraft:egg",
+      "count": 16
+    },
+    {
+      "item": "techreborn:cell",
+      "nbt": "null"
+    }
+  ],
+  "results": [
+	{
+	  "item": "techreborn:cell",
+	  "nbt": {
+		"fluid": "techreborn:methane"
+	  }
+	},
+	{
+	  "item": "techreborn:calcite_dust"
+	}
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/centrifuge/tuff.json
+++ b/src/main/resources/data/techreborn/recipes/centrifuge/tuff.json
@@ -1,0 +1,21 @@
+{
+  "type": "techreborn:centrifuge",
+  "power": 5,
+  "time": 2500,
+  "ingredients": [
+    {
+      "item": "minecraft:tuff",
+      "count": 16
+    }
+  ],
+  "results": [
+	{
+	  "item": "techreborn:dark_ashes_dust",
+	  "count": 18
+	},
+	{
+	  "item": "techreborn:ashes_dust",
+	  "count": 12
+	}
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/centrifuge/turtle_egg.json
+++ b/src/main/resources/data/techreborn/recipes/centrifuge/turtle_egg.json
@@ -1,0 +1,26 @@
+{
+  "type": "techreborn:centrifuge",
+  "power": 5,
+  "time": 5000,
+  "ingredients": [
+    {
+      "item": "minecraft:turtle_egg",
+      "count": 32
+    },
+    {
+      "item": "techreborn:cell",
+      "nbt": "null"
+    }
+  ],
+  "results": [
+	{
+	  "item": "techreborn:cell",
+	  "nbt": {
+		"fluid": "techreborn:methane"
+	  }
+	},
+	{
+	  "item": "techreborn:calcite_dust"
+	}
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/compressor/calcite.json
+++ b/src/main/resources/data/techreborn/recipes/compressor/calcite.json
@@ -1,0 +1,16 @@
+{
+  "type": "techreborn:compressor",
+  "power": 10,
+  "time": 300,
+  "ingredients": [
+    {
+      "tag": "c:calcite_small_dusts",
+      "count": 5
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:calcite"
+    }
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/crafting_table/parts/plantball_from_grass_variants.json
+++ b/src/main/resources/data/techreborn/recipes/crafting_table/parts/plantball_from_grass_variants.json
@@ -1,0 +1,36 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "group": "plantball",
+  "ingredients": [
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	}
+  ],
+  "result": {
+	"item": "techreborn:plantball"
+  }
+}

--- a/src/main/resources/data/techreborn/recipes/crafting_table/parts/plantball_from_grass_variants.json
+++ b/src/main/resources/data/techreborn/recipes/crafting_table/parts/plantball_from_grass_variants.json
@@ -1,0 +1,36 @@
+{
+  "type": "c:crafting_shapeless",
+  "group": "plantball",
+  "ingredients": [
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	},
+	{
+	  "tag": "c:grass_variants"
+	}
+  ],
+  "result": {
+	"item": "techreborn:plantball"
+  }
+}

--- a/src/main/resources/data/techreborn/recipes/crafting_table/parts/plantball_from_kelp.json
+++ b/src/main/resources/data/techreborn/recipes/crafting_table/parts/plantball_from_kelp.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " X ",
+    "XXX",
+    " X "
+  ],
+  "key": {
+    "X": {
+      "item": "minecraft:kelp"
+    }
+  },
+  "result": {
+    "item": "techreborn:plantball"
+  }
+}

--- a/src/main/resources/data/techreborn/recipes/crafting_table/parts/plantball_from_kelp.json
+++ b/src/main/resources/data/techreborn/recipes/crafting_table/parts/plantball_from_kelp.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " X ",
+    "XXX",
+    " X "
+  ],
+  "key": {
+    "X": {
+      "tag": "minecraft:kelp"
+    }
+  },
+  "result": {
+    "item": "techreborn:plantball"
+  }
+}

--- a/src/main/resources/data/techreborn/recipes/crafting_table/parts/plantball_from_sugar_cane.json
+++ b/src/main/resources/data/techreborn/recipes/crafting_table/parts/plantball_from_sugar_cane.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " X ",
+    "XXX",
+    " X "
+  ],
+  "key": {
+    "X": {
+      "item": "minecraft:sugar_cane"
+    }
+  },
+  "result": {
+    "item": "techreborn:plantball"
+  }
+}

--- a/src/main/resources/data/techreborn/recipes/crafting_table/parts/plantball_from_sugar_cane.json
+++ b/src/main/resources/data/techreborn/recipes/crafting_table/parts/plantball_from_sugar_cane.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " X ",
+    "XXX",
+    " X "
+  ],
+  "key": {
+    "X": {
+      "tag": "minecraft:sugar_cane"
+    }
+  },
+  "result": {
+    "item": "techreborn:plantball"
+  }
+}


### PR DESCRIPTION
3 new recipes for plantball. 1 via 3x3 grass variants (new tag), 1 via cross/ball per kelp and sugar so it doesn't take up the space of a storage block in other mods maybe.
5 small calcite dust -> calcite (requiring one more small dust than yielded by grinding calcite)
Centrifuge recipes for eggs and turtle eggs, yielding methane and a bit of calcite dust
Centrifuge recipe for tuff into ashes and dark ashes.

Sorry that the commits are bit strange. Amended an already pushed commit, had to merge.