### PR TITLE
Added optional removal of the current recipe unlock

### DIFF
--- a/src/main/java/techreborn/blocks/misc/BlockRubberLog.java
+++ b/src/main/java/techreborn/blocks/misc/BlockRubberLog.java
@@ -46,6 +46,7 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 import reborncore.common.util.WorldUtils;
+import techreborn.config.TechRebornConfig;
 import techreborn.events.TRRecipeHandler;
 import techreborn.init.ModSounds;
 import techreborn.init.TRContent;
@@ -149,7 +150,7 @@ public class BlockRubberLog extends PillarBlock {
 				if (!playerIn.getInventory().insertStack(TRContent.Parts.SAP.getStack())) {
 					WorldUtils.dropItem(TRContent.Parts.SAP.getStack(), worldIn, pos.offset(hitResult.getSide()));
 				}
-				if (playerIn instanceof ServerPlayerEntity) {
+				if (playerIn instanceof ServerPlayerEntity && !TechRebornConfig.vanillaUnlockRecipes) {
 					TRRecipeHandler.unlockTRRecipes((ServerPlayerEntity) playerIn);
 				}
 				return ActionResult.SUCCESS;

--- a/src/main/java/techreborn/config/TechRebornConfig.java
+++ b/src/main/java/techreborn/config/TechRebornConfig.java
@@ -568,6 +568,9 @@ public class TechRebornConfig {
 	@Config(config = "misc", category = "general", key = "manualRefund", comment = "Allow refunding items used to craft the manual")
 	public static boolean allowManualRefund = true;
 
+	@Config(config = "misc", category = "general", key = "vanillaUnlockRecipes", comment = "Enable recipe unlocks only with vanilla mechanic, instead of getting all of them at once")
+	public static boolean vanillaUnlockRecipes = false;
+
 	@Config(config = "misc", category = "nuke", key = "fusetime", comment = "Nuke fuse time (ticks)")
 	public static int nukeFuseTime = 400;
 


### PR DESCRIPTION
Should default to false in old and new configs, ie no new behaviour, but now I can deactivate it via config instead of using an unofficial distribution. Will probably come back to this once the toasts are finished...