### PR TITLE
Small Piglin tag update

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/guarded_by_piglins.json
+++ b/src/main/resources/data/minecraft/tags/blocks/guarded_by_piglins.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "techreborn:electrum_storage_block"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/ignored_by_piglin_babies.json
+++ b/src/main/resources/data/minecraft/tags/items/ignored_by_piglin_babies.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "techreborn:electrum_nugget",
+	"techreborn:electrum_ingot"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/piglin_loved.json
+++ b/src/main/resources/data/minecraft/tags/items/piglin_loved.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+	"techreborn:gold_plate",
+    "techreborn:electrum_ingot",
+	"techreborn:electrum_storage_block"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/piglin_loved.json
+++ b/src/main/resources/data/minecraft/tags/items/piglin_loved.json
@@ -2,6 +2,8 @@
   "replace": false,
   "values": [
 	"techreborn:gold_plate",
+	"techreborn:gold_cable",
+	"techreborn:insulated_gold_cable",
 	"techreborn:electrum_ingot",
 	"techreborn:electrum_plate",
 	"techreborn:electrum_storage_block"

--- a/src/main/resources/data/minecraft/tags/items/piglin_loved.json
+++ b/src/main/resources/data/minecraft/tags/items/piglin_loved.json
@@ -2,7 +2,8 @@
   "replace": false,
   "values": [
 	"techreborn:gold_plate",
-    "techreborn:electrum_ingot",
+	"techreborn:electrum_ingot",
+	"techreborn:electrum_plate",
 	"techreborn:electrum_storage_block"
   ]
 }


### PR DESCRIPTION
added gold plate and electrum to piglin stuff. Piglins should be able to smell the gold out of an electrum ingot and a block, but not a nugget. Baby piglins are worse at this.

Explicitly used TR IDs instead of c tags because this is part of TR flavor imo