### PR TITLE
rebalanced tank capacities

### DIFF
--- a/src/main/java/techreborn/config/TechRebornConfig.java
+++ b/src/main/java/techreborn/config/TechRebornConfig.java
@@ -439,25 +439,25 @@ public class TechRebornConfig {
 	public static int electricFurnaceMaxEnergy = 1000;
 
 	@Config(config = "machines", category = "storage", key = "CrudeStorageUnitMaxStorage", comment = "Maximum amount of items a Crude Storage Unit can store")
-	public static int crudeStorageUnitMaxStorage = 2048;
+	public static int crudeStorageUnitMaxStorage = 1 << 11; // 2^11, around 2,000, holds 2^5=32 64-stacks
 
 	@Config(config = "machines", category = "storage", key = "BasicStorageUnitMaxStorage", comment = "Maximum amount of items a Basic Storage Unit can store")
-	public static int basicStorageUnitMaxStorage = 8192;
+	public static int basicStorageUnitMaxStorage = 1 << 13; // 2^13, around 8,000, holds 2^7=128 64-stacks
 
 	@Config(config = "machines", category = "storage", key = "BasicTankUnitCapacity", comment = "How much liquid a Basic Tank Unit can take (Value in buckets, 1000 Mb)")
-	public static int basicTankUnitCapacity = 35;
+	public static int basicTankUnitCapacity = 1 << 7; // 2^7=128, holds 2^3=8 16-stacks cells (content only)
 
 	@Config(config = "machines", category = "storage", key = "AdvancedStorageMaxStorage", comment = "Maximum amount of items an Advanced Storage Unit can store")
-	public static int advancedStorageUnitMaxStorage = 32768;
+	public static int advancedStorageUnitMaxStorage = 1 << 15; // 2^15, around 32,000, holds 2^9=512 64-stacks
 
 	@Config(config = "machines", category = "storage", key = "AdvancedTankUnitMaxStorage", comment = "How much liquid an Advanced Tank Unit can take (Value in buckets, 1000 Mb)")
-	public static int advancedTankUnitMaxStorage = 200;
+	public static int advancedTankUnitMaxStorage = 1 << 9; // 2^9=512, holds 2^5=32 16-stacks cells (content only)
 
 	@Config(config = "machines", category = "storage", key = "IndustrialStorageMaxStorage", comment = "Maximum amount of items an Industrial Storage Unit can store (Compat: >= 32768)")
-	public static int industrialStorageUnitMaxStorage = 65536;
+	public static int industrialStorageUnitMaxStorage = 1 << 16; // 2^16, around 65,000, holds 2^10=1024 64-stacks
 
 	@Config(config = "machines", category = "storage", key = "IndustrialTankUnitCapacity", comment = "How much liquid an Industrial Tank Unit can take (Value in buckets, 1000 Mb)")
-	public static int industrialTankUnitCapacity = 500;
+	public static int industrialTankUnitCapacity = 1 << 10; // 2^10, around 1,000, holds 2^6=64 16-stacks cells (content only)
 
 	@Config(config = "machines", category = "storage", key = "QuantumStorageUnitMaxStorage", comment = "Maximum amount of items a Quantum Storage Unit can store (Compat: == MAX_VALUE)")
 	public static int quantumStorageUnitMaxStorage = Integer.MAX_VALUE;


### PR DESCRIPTION
I increased the capacity of tanks to be even remotely considered an alternative to storage units with cells. I kept the values conservative since increasing is always an option, but decreasing might cause item loss.

Changes:
Basic Tank: 35 -> 128 (about 3.5 times)
Advanced Tank: 200 -> 512 (about 2.5 times)
Industrial Tank: 500 -> 1024 (about 2 times)

I oriented myself at the storage unit steps, which are quadrupled with each tier until advanced, then doubled to industrial.

While I was at it, I changed everything to powers of 2 with the shift operator (so other code readers aren't too confused about seemingly arbitrary values) and added explaining comments.