### PR TITLE
Change recipe output of Industrial Grinder for Iridium

### DIFF
--- a/src/main/resources/data/techreborn/recipes/industrial_grinder/iridium_ore_with_mercury.json
+++ b/src/main/resources/data/techreborn/recipes/industrial_grinder/iridium_ore_with_mercury.json
@@ -13,7 +13,8 @@
   ],
   "results": [
     {
-      "item": "techreborn:iridium_ingot"
+      "item": "techreborn:raw_iridium",
+	  "count" : 2
     },
     {
       "item": "techreborn:platinum_dust"

--- a/src/main/resources/data/techreborn/recipes/industrial_grinder/iridium_ore_with_water.json
+++ b/src/main/resources/data/techreborn/recipes/industrial_grinder/iridium_ore_with_water.json
@@ -13,7 +13,7 @@
   ],
   "results": [
     {
-      "item": "techreborn:iridium_ingot"
+      "item": "techreborn:raw_iridium"
     },
     {
       "item": "techreborn:platinum_small_dust",


### PR DESCRIPTION
Changes primary output to 2x raw iridium as other recipes that use mercury with this machine generally have a greater output than just with water.
Makes more sense to have the raw ore as the output from this machine instead of an ingot, which you would usually get from a furnace of some type.