### PR TITLE
Allow Drain drain Cauldrons

### DIFF
--- a/src/main/java/techreborn/blockentity/machine/misc/DrainBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/misc/DrainBlockEntity.java
@@ -24,11 +24,10 @@
 
 package techreborn.blockentity.machine.misc;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.FluidDrainable;
+import net.minecraft.block.*;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.Fluids;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -88,6 +87,26 @@ public class DrainBlockEntity extends MachineBaseBlockEntity implements IToolDro
 			} else {
 				TechReborn.LOGGER.debug("Could not get Fluid from ItemStack " + fluidContainer.getItem());
 			}
+		}
+		if (aboveBlock instanceof LeveledCauldronBlock && aboveBlockState.isOf(Blocks.WATER_CAULDRON)) { //ensure Water cauldron
+			Fluid drainFluid = Fluids.WATER;
+			int level;
+			if (aboveBlockState.contains(LeveledCauldronBlock.LEVEL)){
+				level = aboveBlockState.get(LeveledCauldronBlock.LEVEL);
+			}
+			else {
+				return;
+			}
+			world.setBlockState(above, Blocks.CAULDRON.getDefaultState());
+			internalTank.setFluidInstance(
+				new FluidInstance(drainFluid, FluidValue.BUCKET.fraction(3).multiply(level))
+			);
+		}
+		if (aboveBlock instanceof LavaCauldronBlock){
+			world.setBlockState(above, Blocks.CAULDRON.getDefaultState());
+			internalTank.setFluidInstance(
+				new FluidInstance(Fluids.LAVA, FluidValue.BUCKET)
+			);
 		}
 	}
 


### PR DESCRIPTION
There's no proper fluid interface in cauldron block so its only working for Water and Lava. If any mods uses cauldron as other fluid holder, it might have to change, but I've never seen one.