### PR TITLE
Cache BFS Result and use when its possible

### DIFF
--- a/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
@@ -59,7 +59,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CableBlockEntity extends BlockEntity
-		implements BlockEntityTicker<CableBlockEntity>, IListInfoProvider, IToolDrop {
+		implements BlockEntityTicker<CableBlockEntity>, IListInfoProvider, IToolDrop, CableBlockEntityCache {
 	// Can't use SimpleEnergyStorage because the cable type is not available when the BE is constructed.
 	final SimpleSidedEnergyContainer energyContainer = new SimpleSidedEnergyContainer() {
 		@Override
@@ -160,7 +160,7 @@ public class CableBlockEntity extends BlockEntity
 				boolean foundSomething = false;
 
 				BlockPos adjPos = getPos().offset(direction);
-				BlockEntity adjBe = serverWorld.getBlockEntity(adjPos);
+				BlockEntity adjBe = (CableBlockEntity) CableBlockEntity.CACHE.find(serverWorld, adjPos, null);
 
 				if (adjBe instanceof CableBlockEntity adjCable) {
 					if (adjCable.getCableType().transferRate == getCableType().transferRate) {

--- a/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
@@ -113,7 +113,8 @@ public class CableBlockEntity extends BlockEntity
 		}
 		Block block = world.getBlockState(pos).getBlock();
 		if (block instanceof CableBlock) {
-			return ((CableBlock) block).type;
+			cableType = ((CableBlock) block).type;
+			return cableType;
 		}
 		//Something has gone wrong if this happens
 		return TRContent.Cables.COPPER;
@@ -154,7 +155,7 @@ public class CableBlockEntity extends BlockEntity
 		if (targets == null) {
 			BlockState newBlockState = getCachedState();
 
-			targets = new ArrayList<>();
+			targets = new ArrayList<>(6);
 			for (Direction direction : Direction.values()) {
 				boolean foundSomething = false;
 

--- a/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
@@ -160,7 +160,7 @@ public class CableBlockEntity extends BlockEntity
 				boolean foundSomething = false;
 
 				BlockPos adjPos = getPos().offset(direction);
-				BlockEntity adjBe = (CableBlockEntity) CableBlockEntity.CACHE.find(serverWorld, adjPos, null);
+				BlockEntity adjBe = CableTickManager.getOrCache((ServerWorld) world,adjPos);
 
 				if (adjBe instanceof CableBlockEntity adjCable) {
 					if (adjCable.getCableType().transferRate == getCableType().transferRate) {

--- a/src/main/java/techreborn/blockentity/cable/CableBlockEntityCache.java
+++ b/src/main/java/techreborn/blockentity/cable/CableBlockEntityCache.java
@@ -1,0 +1,9 @@
+package techreborn.blockentity.cable;
+
+import net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup;
+import net.minecraft.util.Identifier;
+
+public interface CableBlockEntityCache {
+	BlockApiLookup<CableBlockEntityCache, Void> CACHE = BlockApiLookup.get(new Identifier("techreborn","cable"), CableBlockEntityCache.class, Void.class);
+
+}

--- a/src/main/java/techreborn/blockentity/cable/CableBlockEntityCache.java
+++ b/src/main/java/techreborn/blockentity/cable/CableBlockEntityCache.java
@@ -1,9 +1,9 @@
 package techreborn.blockentity.cable;
 
+
 import net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup;
 import net.minecraft.util.Identifier;
 
 public interface CableBlockEntityCache {
-	BlockApiLookup<CableBlockEntityCache, Void> CACHE = BlockApiLookup.get(new Identifier("techreborn","cable"), CableBlockEntityCache.class, Void.class);
-
+	BlockApiLookup<CableBlockEntityCache, Void> CACHE = BlockApiLookup.get(new Identifier("techreborn","cable"), CableBlockEntityCache.class, Void.class) ;
 }

--- a/src/main/java/techreborn/blockentity/cable/CableTickManager.java
+++ b/src/main/java/techreborn/blockentity/cable/CableTickManager.java
@@ -111,12 +111,18 @@ class CableTickManager {
 	private static boolean isCacheValid(CableBlockEntity cableBlockEntity){
 		HashSet<CableBlockEntity> cableList = cableLinkedCache.get(cableBlockEntity);
 		if (cableList != null){
+			boolean mark = true;
+			ArrayList<CableBlockEntity> listToRemove = new ArrayList<>();
 			for (CableBlockEntity cables : cableList){
 				if (cables.targets == null || cables.isRemoved() ){
-					return false;
+					listToRemove.add(cables);
+					mark = false;
 				}
 			}
-			return true;
+			for (CableBlockEntity removeCable : listToRemove){
+				cableLinkedCache.remove(removeCable);
+			}
+			return mark;
 		}
 		return false;
 	}

--- a/src/main/java/techreborn/blockentity/cable/CableTickManager.java
+++ b/src/main/java/techreborn/blockentity/cable/CableTickManager.java
@@ -25,8 +25,14 @@
 package techreborn.blockentity.cable;
 
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.fabricmc.fabric.api.lookup.v1.block.BlockApiCache;
+import net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup;
 import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
+import net.fabricmc.fabric.impl.lookup.block.BlockApiCacheImpl;
+import net.minecraft.block.ObserverBlock;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 import team.reborn.energy.api.EnergyStorage;
@@ -40,7 +46,6 @@ class CableTickManager {
 	private static final HashSet<HashSet<CableBlockEntity>> cableTickCache = new HashSet<>(1024);
 	private static final List<OfferedEnergyStorage> targetStorages = new ArrayList<>();
 	private static final HashMap<CableBlockEntity, HashSet<CableBlockEntity>> cableLinkedCache = new HashMap<>();
-
 
 	static void handleCableTick(CableBlockEntity startingCable) {
 		if (!(startingCable.getWorld() instanceof ServerWorld)) throw new IllegalStateException();
@@ -152,7 +157,7 @@ class CableTickManager {
 		while (!bfsQueue.isEmpty()){
 			CableBlockEntity where = bfsQueue.removeFirst();
 			for (Direction direction : Direction.values()){
-				if (world.getBlockEntity(where.getPos().offset(direction)) instanceof CableBlockEntity adjCable && !cableList.contains(adjCable) && adjCable.getCableType() == cableType ){
+				if (CableBlockEntity.CACHE.find(world, where.getPos().offset(direction), null) instanceof CableBlockEntity adjCable && !cableList.contains(adjCable) && adjCable.getCableType() == cableType ){
 					bfsQueue.add(adjCable);
 					cableList.add(adjCable);
 				}


### PR DESCRIPTION
Reduces 8.5mspt -> 5.5mspt for 9300 glass fiber cables.
![2022-03-03_01 04 31](https://user-images.githubusercontent.com/35677394/156401681-c2066025-da95-4292-b723-e6b9946d269b.png)
![2022-03-03_00 59 40](https://user-images.githubusercontent.com/35677394/156401695-2a2d6667-7acf-4449-a3d1-03ad94f50f34.png)
Confirmed working in sp / mp but test / review required, there might be edge case I'm not aware of.
