### PR TITLE
Cable optimization: use BlockApiCache to get adjacent BE

### DIFF
--- a/src/main/java/techreborn/blockentity/cable/CableTickManager.java
+++ b/src/main/java/techreborn/blockentity/cable/CableTickManager.java
@@ -118,9 +118,7 @@ class CableTickManager {
 			CableBlockEntity current = bfsQueue.removeFirst();
 
 			for (Direction direction : Direction.values()) {
-				BlockPos adjPos = current.getPos().offset(direction);
-
-				if (current.getWorld().getBlockEntity(adjPos) instanceof CableBlockEntity adjCable && current.getCableType() == adjCable.getCableType()) {
+				if (current.getAdjacentBlockEntity(direction) instanceof CableBlockEntity adjCable && current.getCableType() == adjCable.getCableType()) {
 					if (shouldTickCable(adjCable)) {
 						bfsQueue.add(adjCable);
 						adjCable.lastTick = tickCounter;


### PR DESCRIPTION
The optimization relies on `BlockApiCache#getBlockEntity` caching the target block entity, which completely eliminates the BE queries from the world starting from the second tick.