### PR TITLE
Cache Torus.generate result for Origin

### DIFF
--- a/RebornCore/src/main/java/reborncore/common/util/Torus.java
+++ b/RebornCore/src/main/java/reborncore/common/util/Torus.java
@@ -24,11 +24,13 @@
 
 package reborncore.common.util;
 
+import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import net.minecraft.util.math.BlockPos;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -37,8 +39,16 @@ import java.util.concurrent.TimeUnit;
 public class Torus {
 	private static final ExecutorService GEN_EXECUTOR = Executors.newSingleThreadExecutor();
 	private static Int2IntMap torusSizeCache;
-
+	private static final HashMap<Integer, ImmutableList<BlockPos>> torusListCache = new HashMap<>();
 	public static List<BlockPos> generate(BlockPos origin, int radius) {
+		boolean putCache = false;
+		if (origin == BlockPos.ORIGIN){
+			if(torusListCache.containsKey(radius)){
+				return torusListCache.get(radius);
+			}
+			putCache = true;
+		}
+
 		List<BlockPos> posLists = new ArrayList<>();
 		for (int x = -radius; x < radius; x++) {
 			for (int y = -radius; y < radius; y++) {
@@ -49,6 +59,7 @@ public class Torus {
 				}
 			}
 		}
+		if (putCache) torusListCache.put(radius, ImmutableList.copyOf(posLists));
 		return posLists;
 	}
 

--- a/src/main/java/techreborn/blockentity/machine/multiblock/FusionControlComputerBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/multiblock/FusionControlComputerBlockEntity.java
@@ -391,7 +391,7 @@ public class FusionControlComputerBlockEntity extends GenericMachineBlockEntity 
 	@Override
 	public void writeMultiblock(MultiblockWriter writer) {
 		BlockState coil = TRContent.Machine.FUSION_COIL.block.getDefaultState();
-		Torus.generate(BlockPos.ORIGIN, size).forEach(pos -> writer.add(pos.getX(), pos.getY(), pos.getZ(), coil));
+		Torus.getOriginPositions(size).forEach(pos -> writer.add(pos.getX(), pos.getY(), pos.getZ(), coil));
 	}
 
 	@Override


### PR DESCRIPTION
Fusion Coils are laggy, not by ticking block entities, just purely by torus.generate(BlockPos.origin, size)

Int2ObjectMap can be used alternatively tho.