### PR TITLE
Fix #2850 Fetching cooking time based on recipe

### DIFF
--- a/src/gametest/groovy/techreborn/test/TRTestContext.groovy
+++ b/src/gametest/groovy/techreborn/test/TRTestContext.groovy
@@ -28,7 +28,7 @@ import net.minecraft.item.ItemConvertible
 import net.minecraft.item.ItemStack
 import net.minecraft.test.TestContext
 import net.minecraft.util.math.BlockPos
-import techreborn.blockentity.machine.GenericMachineBlockEntity
+import reborncore.common.blockentity.MachineBaseBlockEntity
 import techreborn.init.TRContent
 
 class TRTestContext extends TestContext {
@@ -54,6 +54,20 @@ class TRTestContext extends TestContext {
             }
         }
     }
+
+	def machine(TRContent.Machine machine, @DelegatesTo(MachineContext) Closure machineContextClosure) {
+		def machinePos = new BlockPos(0, 1, 0)
+		setBlockState(machinePos, machine.block)
+
+		waitAndRun(5) {
+			try {
+				new MachineContext(machinePos).with(machineContextClosure)
+			} catch (e) {
+				e.printStackTrace()
+				throw e
+			}
+		}
+	}
 
     class MachineContext {
         final BlockPos machinePos
@@ -100,14 +114,14 @@ class TRTestContext extends TestContext {
             }
         }
 
-        GenericMachineBlockEntity getBlockEntity() {
+		MachineBaseBlockEntity getBlockEntity() {
             def be = getBlockEntity(machinePos)
 
             if (!be) {
                 throwPositionedException("Failed to get machine block entity", machinePos)
             }
 
-            return be as GenericMachineBlockEntity
+            return be as MachineBaseBlockEntity
         }
     }
 }

--- a/src/gametest/groovy/techreborn/test/machine/IronAlloyFurnaceTest.groovy
+++ b/src/gametest/groovy/techreborn/test/machine/IronAlloyFurnaceTest.groovy
@@ -1,0 +1,51 @@
+/*
+ * This file is part of TechReborn, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2020 TechReborn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+//file:noinspection GrMethodMayBeStatic
+package techreborn.test.machine
+
+import net.minecraft.item.Items
+import net.minecraft.test.GameTest
+import techreborn.blockentity.machine.iron.IronAlloyFurnaceBlockEntity
+import techreborn.config.TechRebornConfig
+import techreborn.init.TRContent
+import techreborn.test.TRGameTest
+import techreborn.test.TRTestContext
+
+class IronAlloyFurnaceTest extends TRGameTest {
+    @GameTest(structureName = "fabric-gametest-api-v1:empty", tickLimit = 2000)
+    def testIronAlloyFurnaceElectrumAlloyIngot(TRTestContext context) {
+        /**
+         * Test that the Iron Alloy Furnace smelts a gold ingot and a silver ingot into an electrum alloy ingot in 200
+		 * Verifies: Issue #2850
+         */
+        context.machine(TRContent.Machine.IRON_ALLOY_FURNACE) {
+			input(Items.COAL_BLOCK, IronAlloyFurnaceBlockEntity.FUEL_SLOT)
+            input(Items.GOLD_INGOT, IronAlloyFurnaceBlockEntity.INPUT_SLOT_1)
+            input(TRContent.Ingots.SILVER, IronAlloyFurnaceBlockEntity.INPUT_SLOT_2)
+
+            expectOutput(TRContent.Ingots.ELECTRUM, (int) (200 / TechRebornConfig.cookingScale), IronAlloyFurnaceBlockEntity.OUTPUT_SLOT)
+        }
+    }
+}

--- a/src/gametest/groovy/techreborn/test/machine/IronFurnaceTest.groovy
+++ b/src/gametest/groovy/techreborn/test/machine/IronFurnaceTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * This file is part of TechReborn, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2020 TechReborn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+//file:noinspection GrMethodMayBeStatic
+package techreborn.test.machine
+
+
+import net.minecraft.item.Items
+import net.minecraft.test.GameTest
+import techreborn.blockentity.machine.iron.IronFurnaceBlockEntity
+import techreborn.config.TechRebornConfig
+import techreborn.init.TRContent
+import techreborn.test.TRGameTest
+import techreborn.test.TRTestContext
+
+class IronFurnaceTest extends TRGameTest {
+	@GameTest(structureName = "fabric-gametest-api-v1:empty", tickLimit = 2000)
+	def testIronFurnaceSmeltRawIron(TRTestContext context) {
+		/**
+		 * Test that the Iron Furnace smelts a raw iron ore into an iron ingot in 200 ticks
+		 * Verifies: Issue #2850
+		 */
+		context.machine(TRContent.Machine.IRON_FURNACE) {
+			input(Items.COAL_BLOCK, IronFurnaceBlockEntity.FUEL_SLOT)
+			input(Items.RAW_IRON, IronFurnaceBlockEntity.INPUT_SLOT)
+
+			expectOutput(Items.IRON_INGOT, (int) (200 / TechRebornConfig.cookingScale), IronFurnaceBlockEntity.OUTPUT_SLOT)
+		}
+	}
+
+    @GameTest(structureName = "fabric-gametest-api-v1:empty", tickLimit = 2000)
+    def testIronFurnaceSmeltRawIronBlock(TRTestContext context) {
+        /**
+         * Test that the Iron Furnace smelts a raw iron block into an iron block in 1500 ticks instead of 200
+		 * Verifies: Issue #2850
+         */
+        context.machine(TRContent.Machine.IRON_FURNACE) {
+			input(Items.COAL_BLOCK, IronFurnaceBlockEntity.FUEL_SLOT)
+            input(Items.RAW_IRON_BLOCK, IronFurnaceBlockEntity.INPUT_SLOT)
+
+            expectOutput(Items.IRON_BLOCK, (int) (1500 / TechRebornConfig.cookingScale), IronFurnaceBlockEntity.OUTPUT_SLOT)
+        }
+    }
+}

--- a/src/gametest/resources/fabric.mod.json
+++ b/src/gametest/resources/fabric.mod.json
@@ -6,8 +6,10 @@
   "environment": "*",
   "entrypoints": {
 	"fabric-gametest" : [
-	  "techreborn.test.machine.GrinderTest",
-	  "techreborn.test.recipe.RecipeSyncTests"
+		"techreborn.test.machine.GrinderTest",
+		"techreborn.test.machine.IronFurnaceTest",
+		"techreborn.test.machine.IronAlloyFurnaceTest",
+		"techreborn.test.recipe.RecipeSyncTests"
 	]
   }
 }

--- a/src/main/java/techreborn/blockentity/machine/iron/AbstractIronMachineBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/iron/AbstractIronMachineBlockEntity.java
@@ -47,15 +47,12 @@ public abstract class AbstractIronMachineBlockEntity extends MachineBaseBlockEnt
 	public int burnTime;
 	public int totalBurnTime;
 	public int progress;
-	public int totalCookingTime;
 	int fuelSlot;
 	Block toolDrop;
 
 	public AbstractIronMachineBlockEntity(BlockEntityType<?> blockEntityTypeIn, BlockPos pos, BlockState state, int fuelSlot, Block toolDrop) {
 		super(blockEntityTypeIn, pos, state);
 		this.fuelSlot = fuelSlot;
-		// default value for vanilla smelting recipes is 200
-		this.totalCookingTime = (int) (200 / TechRebornConfig.cookingScale);
 		this.toolDrop = toolDrop;
 	}
 
@@ -70,6 +67,12 @@ public abstract class AbstractIronMachineBlockEntity extends MachineBaseBlockEnt
 	 * item in the output slot
 	 */
 	protected abstract void smelt();
+
+	/**
+	 * Get the current recipe's cooking time
+	 *
+	 */
+	protected abstract int cookingTime();
 
 	/**
 	 * Returns the number of ticks that the supplied fuel item will keep the
@@ -106,8 +109,8 @@ public abstract class AbstractIronMachineBlockEntity extends MachineBaseBlockEnt
 	 * @return {@code int} Scaled crafting progress
 	 */
 	public int getProgressScaled(int scale) {
-		if (totalCookingTime > 0) {
-			return progress * scale / totalCookingTime;
+		if (cookingTime() > 0) {
+			return progress * scale / cookingTime();
 		}
 		return 0;
 	}
@@ -174,7 +177,7 @@ public abstract class AbstractIronMachineBlockEntity extends MachineBaseBlockEnt
 
 		if (isBurning() && canSmelt()) {
 			++progress;
-			if (progress == totalCookingTime) {
+			if (progress == cookingTime()) {
 				progress = 0;
 				smelt();
 			}
@@ -231,6 +234,4 @@ public abstract class AbstractIronMachineBlockEntity extends MachineBaseBlockEnt
 	public void setProgress(int progress) {
 		this.progress = progress;
 	}
-
-
 }


### PR DESCRIPTION
These changes affect AbstractIronMachineBlockEntity and all subclasses. A new abstract method has been added as replacement for the `totalCookingTime` field, to facilitate the subclasses to provide the cooking time, either by looking it up in the current active recipe, or provide a default time (The previous 200 tick value)

I've also expanded the `TRTestContext` to work with non-powered machines by relaxing the type of `GenericMachineBlockEntity` to `MachineBaseBlockEntity`, and created tests for validating the expected behavior

Fixes #2850 


All GameTests pass using "runGametest" and "runGametestClient" gradle tasks