### PR TITLE
New recipes + 1 nerf

### DIFF
--- a/src/datagen/groovy/techreborn/datagen/recipes/machine/grinder/GrinderRecipesProvider.groovy
+++ b/src/datagen/groovy/techreborn/datagen/recipes/machine/grinder/GrinderRecipesProvider.groovy
@@ -48,6 +48,8 @@ class GrinderRecipesProvider extends TechRebornRecipesProvider {
 		// vanilla ingots
 		// TODO vanilla ingots + storage blocks (iron, copper, gold)
 		generateTRIngots()
+		generateSand()
+		generateRedSand()
 	}
 
 	void generateVanillaRawMetals() {
@@ -127,6 +129,34 @@ class GrinderRecipesProvider extends TechRebornRecipesProvider {
 					source "block"
 					criterion getCriterionName(ingot.getStorageBlock().asTag()), getCriterionConditions(ingot.getStorageBlock().asTag())
 				}
+		}
+	}
+
+	void generateSand() {
+		[
+			Items.SANDSTONE, Items.CUT_SANDSTONE, Items.CHISELED_SANDSTONE, Items.SMOOTH_SANDSTONE
+		].each {
+			offerGrinderRecipe {
+				ingredients it
+				outputs new ItemStack(Items.SAND, 3)
+				power 2
+				time 200
+				criterion getCriterionName(it), getCriterionConditions(it)
+			}
+		}
+	}
+
+	void generateRedSand() {
+		[
+			Items.RED_SANDSTONE, Items.CUT_RED_SANDSTONE, Items.CHISELED_RED_SANDSTONE, Items.SMOOTH_RED_SANDSTONE
+		].each {
+			offerGrinderRecipe {
+				ingredients it
+				outputs new ItemStack(Items.RED_SAND, 3)
+				power 2
+				time 200
+				criterion getCriterionName(it), getCriterionConditions(it)
+			}
 		}
 	}
 }

--- a/src/datagen/groovy/techreborn/datagen/recipes/machine/grinder/GrinderRecipesProvider.groovy
+++ b/src/datagen/groovy/techreborn/datagen/recipes/machine/grinder/GrinderRecipesProvider.groovy
@@ -25,6 +25,7 @@
 package techreborn.datagen.recipes.machine.grinder
 
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+import net.minecraft.item.Item
 import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
 import net.minecraft.tag.TagKey
@@ -134,11 +135,20 @@ class GrinderRecipesProvider extends TechRebornRecipesProvider {
 
 	void generateSand() {
 		[
-			Items.SANDSTONE, Items.CUT_SANDSTONE, Items.CHISELED_SANDSTONE, Items.SMOOTH_SANDSTONE
-		].each {
+			(Items.SANDSTONE): 4,
+			(Items.SMOOTH_SANDSTONE): 4,
+			(Items.CUT_SANDSTONE) : 4,
+			(Items.CHISELED_SANDSTONE) :4,
+			(Items.SANDSTONE_STAIRS) : 3,
+			(Items.SMOOTH_SANDSTONE_STAIRS) : 3,
+			(Items.SANDSTONE_WALL) : 3,
+			(Items.SANDSTONE_SLAB) : 2,
+			(Items.CUT_SANDSTONE_SLAB) : 2,
+			(Items.SMOOTH_SANDSTONE_SLAB) : 2,
+		].each {it, count ->
 			offerGrinderRecipe {
 				ingredients it
-				outputs new ItemStack(Items.SAND, 3)
+				outputs new ItemStack(Items.SAND, count)
 				power 2
 				time 200
 				criterion getCriterionName(it), getCriterionConditions(it)
@@ -148,11 +158,20 @@ class GrinderRecipesProvider extends TechRebornRecipesProvider {
 
 	void generateRedSand() {
 		[
-			Items.RED_SANDSTONE, Items.CUT_RED_SANDSTONE, Items.CHISELED_RED_SANDSTONE, Items.SMOOTH_RED_SANDSTONE
-		].each {
+			(Items.RED_SANDSTONE): 4,
+			(Items.SMOOTH_RED_SANDSTONE): 4,
+			(Items.CUT_RED_SANDSTONE) : 4,
+			(Items.CHISELED_RED_SANDSTONE) :4,
+			(Items.RED_SANDSTONE_STAIRS) : 3,
+			(Items.SMOOTH_RED_SANDSTONE_STAIRS) : 3,
+			(Items.RED_SANDSTONE_WALL) : 3,
+			(Items.RED_SANDSTONE_SLAB) : 2,
+			(Items.CUT_RED_SANDSTONE_SLAB) : 2,
+			(Items.SMOOTH_RED_SANDSTONE_SLAB) : 2,
+		].each {it, count ->
 			offerGrinderRecipe {
 				ingredients it
-				outputs new ItemStack(Items.RED_SAND, 3)
+				outputs new ItemStack(Items.RED_SAND, count)
 				power 2
 				time 200
 				criterion getCriterionName(it), getCriterionConditions(it)

--- a/src/datagen/groovy/techreborn/datagen/recipes/machine/grinder/GrinderRecipesProvider.groovy
+++ b/src/datagen/groovy/techreborn/datagen/recipes/machine/grinder/GrinderRecipesProvider.groovy
@@ -145,13 +145,14 @@ class GrinderRecipesProvider extends TechRebornRecipesProvider {
 			(Items.SANDSTONE_SLAB) : 2,
 			(Items.CUT_SANDSTONE_SLAB) : 2,
 			(Items.SMOOTH_SANDSTONE_SLAB) : 2,
-		].each {it, count ->
+		].each {item, count ->
 			offerGrinderRecipe {
-				ingredients it
+				ingredients item
 				outputs new ItemStack(Items.SAND, count)
-				power 2
+				power count
 				time 200
-				criterion getCriterionName(it), getCriterionConditions(it)
+				source item.toString()
+				criterion getCriterionName(item), getCriterionConditions(item)
 			}
 		}
 	}
@@ -168,13 +169,14 @@ class GrinderRecipesProvider extends TechRebornRecipesProvider {
 			(Items.RED_SANDSTONE_SLAB) : 2,
 			(Items.CUT_RED_SANDSTONE_SLAB) : 2,
 			(Items.SMOOTH_RED_SANDSTONE_SLAB) : 2,
-		].each {it, count ->
+		].each {item, count ->
 			offerGrinderRecipe {
-				ingredients it
+				ingredients item
 				outputs new ItemStack(Items.RED_SAND, count)
-				power 2
+				power count
 				time 200
-				criterion getCriterionName(it), getCriterionConditions(it)
+				source item.toString()
+				criterion getCriterionName(item), getCriterionConditions(item)
 			}
 		}
 	}

--- a/src/datagen/groovy/techreborn/datagen/recipes/machine/grinder/GrinderRecipesProvider.groovy
+++ b/src/datagen/groovy/techreborn/datagen/recipes/machine/grinder/GrinderRecipesProvider.groovy
@@ -40,12 +40,22 @@ class GrinderRecipesProvider extends TechRebornRecipesProvider {
 
 	@Override
 	void generateRecipes() {
-		// vanilla raw metals
+		generateVanillaRawMetals()
+		generateTRRawMetals()
+		// vanilla gems
+		// TODO vanilla gems + storage blocks (Redstone, glowstone, lapis, emerald, diamond)
+		generateTRGems()
+		// vanilla ingots
+		// TODO vanilla ingots + storage blocks (iron, copper, gold)
+		generateTRIngots()
+	}
+
+	void generateVanillaRawMetals() {
 		[
-				(Items.RAW_IRON):	(TagKey.of(Registry.ITEM_KEY, new Identifier("c","iron_ores"))),
-				(Items.RAW_COPPER):	(TagKey.of(Registry.ITEM_KEY, new Identifier("c","copper_ores"))),
-				(Items.RAW_GOLD):	(TagKey.of(Registry.ITEM_KEY, new Identifier("c","gold_ores")))
-		].each{raw, oreTag ->
+			(Items.RAW_IRON)  : (TagKey.of(Registry.ITEM_KEY, new Identifier("c", "iron_ores"))),
+			(Items.RAW_COPPER): (TagKey.of(Registry.ITEM_KEY, new Identifier("c", "copper_ores"))),
+			(Items.RAW_GOLD)  : (TagKey.of(Registry.ITEM_KEY, new Identifier("c", "gold_ores")))
+		].each { raw, oreTag ->
 			offerGrinderRecipe {
 				ingredients oreTag
 				outputs new ItemStack(raw, 2)
@@ -54,8 +64,10 @@ class GrinderRecipesProvider extends TechRebornRecipesProvider {
 				criterion getCriterionName(oreTag), getCriterionConditions(oreTag)
 			}
 		}
-		// TR raw metals
-		TRContent.RawMetals.getRM2OBMap().each{raw, ore ->
+	}
+
+	void generateTRRawMetals() {
+		TRContent.RawMetals.getRM2OBMap().each { raw, ore ->
 			if (!ore.isIndustrial())
 				offerGrinderRecipe {
 					ingredients ore.asTag()
@@ -65,9 +77,9 @@ class GrinderRecipesProvider extends TechRebornRecipesProvider {
 					criterion getCriterionName(ore.asTag()), getCriterionConditions(ore.asTag())
 				}
 		}
-		// vanilla gems
-		// TODO vanilla gems + storage blocks (Redstone, glowstone, lapis, emerald, diamond)
-		// TR gems
+	}
+
+	void generateTRGems() {
 		TRContent.Gems.getG2DMap().each {gem, dust ->
 			offerGrinderRecipe {
 				ingredients gem.asTag()
@@ -95,9 +107,9 @@ class GrinderRecipesProvider extends TechRebornRecipesProvider {
 					criterion getCriterionName(gem.getStorageBlock().asTag()), getCriterionConditions(gem.getStorageBlock().asTag())
 				}
 		}
-		// vanilla ingots
-		// TODO vanilla ingots + storage blocks (iron, copper, gold)
-		// TR ingots
+	}
+
+	void generateTRIngots() {
 		TRContent.Ingots.getI2DMap().each {ingot, dust ->
 			offerGrinderRecipe {
 				ingredients ingot.asTag()

--- a/src/main/resources/data/techreborn/advancements/recipes/extractor/paper_from_book.json
+++ b/src/main/resources/data/techreborn/advancements/recipes/extractor/paper_from_book.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+	"recipes": [
+	  "techreborn:extractor/paper_from_book"
+	]
+  },
+  "criteria": {
+	"has_book": {
+	  "trigger": "minecraft:inventory_changed",
+	  "conditions": {
+		"items": [
+		  {
+			"items": ["minecraft:book"]
+		  }
+		]
+	  }
+	},
+	"has_the_recipe": {
+	  "trigger": "minecraft:recipe_unlocked",
+	  "conditions": {
+		"recipe": "techreborn:extractor/paper_from_book"
+	  }
+	}
+  },
+  "requirements": [
+	[
+	  "has_book",
+	  "has_the_recipe"
+	]
+  ]
+}

--- a/src/main/resources/data/techreborn/advancements/recipes/extractor/phantom_membrane_from_elytra.json
+++ b/src/main/resources/data/techreborn/advancements/recipes/extractor/phantom_membrane_from_elytra.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+	"recipes": [
+	  "techreborn:extractor/phantom_membrane_from_elytra"
+	]
+  },
+  "criteria": {
+	"has_elytra": {
+	  "trigger": "minecraft:inventory_changed",
+	  "conditions": {
+		"items": [
+		  {
+			"items": ["minecraft:elytra"]
+		  }
+		]
+	  }
+	},
+	"has_the_recipe": {
+	  "trigger": "minecraft:recipe_unlocked",
+	  "conditions": {
+		"recipe": "techreborn:extractor/phantom_membrane_from_elytra"
+	  }
+	}
+  },
+  "requirements": [
+	[
+	  "has_elytra",
+	  "has_the_recipe"
+	]
+  ]
+}

--- a/src/main/resources/data/techreborn/advancements/recipes/extractor/purple_dye_from_shulker_shell.json
+++ b/src/main/resources/data/techreborn/advancements/recipes/extractor/purple_dye_from_shulker_shell.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+	"recipes": [
+	  "techreborn:extractor/purple_dye_from_shulker_shell"
+	]
+  },
+  "criteria": {
+	"has_shulker_shell": {
+	  "trigger": "minecraft:inventory_changed",
+	  "conditions": {
+		"items": [
+		  {
+			"items": ["minecraft:shulker_shell"]
+		  }
+		]
+	  }
+	},
+	"has_the_recipe": {
+	  "trigger": "minecraft:recipe_unlocked",
+	  "conditions": {
+		"recipe": "techreborn:extractor/purple_dye_from_shulker_shell"
+	  }
+	}
+  },
+  "requirements": [
+	[
+	  "has_shulker_shell",
+	  "has_the_recipe"
+	]
+  ]
+}

--- a/src/main/resources/data/techreborn/advancements/recipes/extractor/sticks_from_armor_stand.json
+++ b/src/main/resources/data/techreborn/advancements/recipes/extractor/sticks_from_armor_stand.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+	"recipes": [
+	  "techreborn:extractor/sticks_from_armor_stand"
+	]
+  },
+  "criteria": {
+	"has_armor_stand": {
+	  "trigger": "minecraft:inventory_changed",
+	  "conditions": {
+		"items": [
+		  {
+			"items": ["minecraft:armor_stand"]
+		  }
+		]
+	  }
+	},
+	"has_the_recipe": {
+	  "trigger": "minecraft:recipe_unlocked",
+	  "conditions": {
+		"recipe": "techreborn:extractor/sticks_from_armor_stand"
+	  }
+	}
+  },
+  "requirements": [
+	[
+	  "has_armor_stand",
+	  "has_the_recipe"
+	]
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/extractor/green_dye.json
+++ b/src/main/resources/data/techreborn/recipes/extractor/green_dye.json
@@ -10,7 +10,7 @@
   "results": [
     {
       "item": "minecraft:green_dye",
-      "count": 2
+      "count": 1
     }
   ]
 }

--- a/src/main/resources/data/techreborn/recipes/extractor/paper_from_book.json
+++ b/src/main/resources/data/techreborn/recipes/extractor/paper_from_book.json
@@ -1,0 +1,16 @@
+{
+  "type": "techreborn:extractor",
+  "power": 10,
+  "time": 200,
+  "ingredients": [
+    {
+      "item": "minecraft:book"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:paper",
+	  "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/extractor/phantom_membrane_from_elytra.json
+++ b/src/main/resources/data/techreborn/recipes/extractor/phantom_membrane_from_elytra.json
@@ -1,0 +1,16 @@
+{
+  "type": "techreborn:extractor",
+  "power": 10,
+  "time": 300,
+  "ingredients": [
+    {
+      "item": "minecraft:elytra"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:phantom_membrane",
+	  "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/extractor/purple_dye_from_shulker_shell.json
+++ b/src/main/resources/data/techreborn/recipes/extractor/purple_dye_from_shulker_shell.json
@@ -1,0 +1,16 @@
+{
+  "type": "techreborn:extractor",
+  "power": 10,
+  "time": 400,
+  "ingredients": [
+    {
+      "item": "minecraft:shulker_shell"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:purple_dye",
+      "count": 4
+    }
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/extractor/sticks_from_armor_stand.json
+++ b/src/main/resources/data/techreborn/recipes/extractor/sticks_from_armor_stand.json
@@ -1,0 +1,16 @@
+{
+  "type": "techreborn:extractor",
+  "power": 10,
+  "time": 300,
+  "ingredients": [
+    {
+      "item": "minecraft:armor_stand"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:stick",
+	  "count": 3
+    }
+  ]
+}


### PR DESCRIPTION
Added a couple of new TR recipes working with vanilla items that couldn't be processed before. Some part is with datagen, and the generation has been tested successfully. 

The recipes have not been tested in-game yet, would be nice if someone could do that.

Only debatable change imho is reducing green dye from plantball to 1 instead of two. Reason: plantballs are easy to get with any leaves or saplings and the usual source of green dye, cacti, require a desert to be found first, making it moderatively hard for first time aquire. Hence the balancing.