### PR TITLE
Fix #2847 Allowing values larger than Integer.MAX_VALUE

### DIFF
--- a/RebornCore/src/main/java/reborncore/client/gui/guibuilder/GuiBuilder.java
+++ b/RebornCore/src/main/java/reborncore/client/gui/guibuilder/GuiBuilder.java
@@ -564,14 +564,14 @@ public class GuiBuilder {
 	 * @param gui             {@link GuiBase} The GUI to draw on
 	 * @param x               {@code int} Top left corner where to place energy bar
 	 * @param y               {@code int} Top left corner where to place energy bar
-	 * @param energyStored    {@code int} Current amount of energy
-	 * @param maxEnergyStored {@code int} Maximum amount of energy
+	 * @param energyStored    {@code long} Current amount of energy
+	 * @param maxEnergyStored {@code long} Maximum amount of energy
 	 * @param mouseX          {@code int} Mouse cursor position to check for tooltip
 	 * @param mouseY          {@code int} Mouse cursor position to check for tooltip
 	 * @param buttonID        {@code int} Button ID used to switch energy systems
 	 * @param layer           {@link GuiBase.Layer} The layer to draw on
 	 */
-	public void drawMultiEnergyBar(MatrixStack matrixStack, GuiBase<?> gui, int x, int y, int energyStored, int maxEnergyStored, int mouseX,
+	public void drawMultiEnergyBar(MatrixStack matrixStack, GuiBase<?> gui, int x, int y, long energyStored, long maxEnergyStored, int mouseX,
 								   int mouseY, int buttonID, GuiBase.Layer layer) {
 		if (gui.hideGuiElements()) return;
 		if (layer == GuiBase.Layer.BACKGROUND) {

--- a/RebornCore/src/main/java/reborncore/common/powerSystem/PowerSystem.java
+++ b/RebornCore/src/main/java/reborncore/common/powerSystem/PowerSystem.java
@@ -42,7 +42,7 @@ public class PowerSystem {
 	}
 
 	public static String getLocalizedPowerNoSuffix(double power) {
-		return getRoundedString((int) power, "", true);
+		return getRoundedString(power, "", true);
 	}
 
 	public static String getLocalizedPowerNoFormat(double power){

--- a/src/main/java/techreborn/blockentity/machine/multiblock/FusionControlComputerBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/multiblock/FusionControlComputerBlockEntity.java
@@ -31,18 +31,19 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
-import reborncore.common.screen.BuiltScreenHandlerProvider;
-import reborncore.common.screen.BuiltScreenHandler;
 import reborncore.client.screen.builder.ScreenHandlerBuilder;
 import reborncore.common.blockentity.MachineBaseBlockEntity;
 import reborncore.common.blockentity.MultiblockWriter;
 import reborncore.common.crafting.RebornRecipe;
 import reborncore.common.crafting.ingredient.RebornIngredient;
+import reborncore.common.screen.BuiltScreenHandler;
+import reborncore.common.screen.BuiltScreenHandlerProvider;
 import reborncore.common.util.ItemUtils;
 import reborncore.common.util.RebornInventory;
 import reborncore.common.util.StringUtils;
@@ -84,23 +85,22 @@ public class FusionControlComputerBlockEntity extends GenericMachineBlockEntity 
 				.orElse(null);
 	}
 
-	//TODO: translate
 	public Text getStateText() {
 		if (state == -1) {
 			return LiteralText.EMPTY;
 		} else if (state == 0) {
-			return new LiteralText("No recipe");
+			return new TranslatableText("gui.techreborn.fusion.norecipe");
 		} else if (state == 1) {
 			FusionReactorRecipe r = getCurrentRecipeFromID();
 			if (r == null) {
-				return new LiteralText("Charging");
+				return new TranslatableText("gui.techreborn.fusion.charging");
 			}
 			int percentage = percentage(r.getStartEnergy(), getEnergy());
-			return new LiteralText("Charging (")
-					.append(StringUtils.getPercentageText(percentage))
-					.append(")");
+			return new TranslatableText("gui.techreborn.fusion.chargingdetailed",
+				new Object[]{StringUtils.getPercentageText(percentage)}
+			);
 		} else if (state == 2) {
-			return new LiteralText("Crafting");
+			return new TranslatableText("gui.techreborn.fusion.crafting");
 		}
 		return LiteralText.EMPTY;
 	}

--- a/src/main/java/techreborn/client/gui/GuiFusionReactor.java
+++ b/src/main/java/techreborn/client/gui/GuiFusionReactor.java
@@ -34,9 +34,9 @@ import reborncore.client.gui.builder.widget.GuiButtonExtended;
 import reborncore.client.gui.builder.widget.GuiButtonUpDown;
 import reborncore.client.gui.builder.widget.GuiButtonUpDown.UpDownButtonType;
 import reborncore.client.gui.guibuilder.GuiBuilder;
-import reborncore.common.screen.BuiltScreenHandler;
 import reborncore.common.network.NetworkManager;
 import reborncore.common.powerSystem.PowerSystem;
+import reborncore.common.screen.BuiltScreenHandler;
 import reborncore.common.util.Color;
 import reborncore.common.util.Torus;
 import techreborn.blockentity.machine.multiblock.FusionControlComputerBlockEntity;
@@ -115,7 +115,7 @@ public class GuiFusionReactor extends GuiBase<BuiltScreenHandler> {
 		drawTextWithShadow(matrixStack, this.textRenderer, new LiteralText("Size: ").append(String.valueOf(blockEntity.size)), 83, 81, 0xFFFFFF);
 		drawTextWithShadow(matrixStack, this.textRenderer, new LiteralText(String.valueOf(blockEntity.getPowerMultiplier())).append("x"), 10, 81, 0xFFFFFF);
 
-		builder.drawMultiEnergyBar(matrixStack, this, 9, 19, (int) this.blockEntity.getEnergy(), (int) this.blockEntity.getMaxStoredPower(), mouseX, mouseY, 0, layer);
+		builder.drawMultiEnergyBar(matrixStack, this, 9, 19, this.blockEntity.getEnergy(), this.blockEntity.getMaxStoredPower(), mouseX, mouseY, 0, layer);
 	}
 
 	public void hologramToggle(GuiButtonExtended button, double x, double y) {

--- a/src/main/resources/assets/techreborn/lang/en_us.json
+++ b/src/main/resources/assets/techreborn/lang/en_us.json
@@ -1084,5 +1084,9 @@
   "gui.techreborn.tank.type": "Fluid Type:",
   "gui.techreborn.tank.amount": "Fluid Amount:",
   "gui.techreborn.storage.store": "Storing:",
-  "gui.techreborn.storage.amount": "Amount:"
+  "gui.techreborn.storage.amount": "Amount:",
+  "gui.techreborn.fusion.norecipe": "No recipe",
+  "gui.techreborn.fusion.charging": "Charging",
+	"gui.techreborn.fusion.chargingdetailed": "Charging (%s)",
+	"gui.techreborn.fusion.crafting": "Crafting"
 }

--- a/src/main/resources/assets/techreborn/lang/en_us.json
+++ b/src/main/resources/assets/techreborn/lang/en_us.json
@@ -857,6 +857,8 @@
   "_comment20": "Death Messages",
   "death.attack.shock": "%s was electrocuted",
   "death.attack.shock.player": "%s was electrocuted trying to outrun %s",
+  "death.attack.fusion": "%s suffered from acute radiation sickness",
+  "death.attack.fusion.player": "%s suffered from acute radiation sickness trying to outrun %s",
 
   "_comment21": "Entities",
   "entity.nuke": "Nuke",


### PR DESCRIPTION
* Allowed the GUI to display `Long` numbers to fix overflow values

* Added missing Death Messages from stepping on the fusion reactor

Fixes #2847 

Old Missing translation:
![image](https://user-images.githubusercontent.com/44922798/160166880-a3b657c7-78dc-4af2-a65a-b619f36fcc47.png)
Fixed death message:
![image](https://user-images.githubusercontent.com/44922798/160167429-6795ca25-49c1-4f8d-980e-f10496365af8.png)


Fixed Tooltip:
![image](https://user-images.githubusercontent.com/44922798/160167244-11d9a575-9bfd-42a5-821e-db448f7a3637.png)


Fixes #2847 