### PR TITLE
#2775 Adding Trinket support for BatpackItem

### DIFF
--- a/RebornCore/src/main/java/reborncore/common/util/ItemUtils.java
+++ b/RebornCore/src/main/java/reborncore/common/util/ItemUtils.java
@@ -280,18 +280,40 @@ public class ItemUtils {
 		}
 
 		for (int i = 0; i < player.getInventory().size(); i++) {
-			ItemStack invStack = player.getInventory().getStack(i);
-
-			if (invStack.isEmpty() || !filter.test(invStack)) {
-				continue;
-			}
-
-			EnergyStorageUtil.move(
-					sourceStorage,
-					ContainerItemContext.ofPlayerSlot(player, playerInv.getSlots().get(i)).find(EnergyStorage.ITEM),
-					maxOutput,
-					null
-			);
+			transferPower(player, i, sourceStorage, maxOutput, filter);
 		}
+	}
+
+	/**
+	 * Output energy from EnergyStorage to other EnergyStorage at slot index.
+	 * <br> <br>
+	 * It is recommended to use {@link ItemUtils#distributePowerToInventory(PlayerEntity, ItemStack, long, Predicate)}
+	 * <br> <br>
+	 * Only outputs energy if the item in the provided slot can accept power
+	 *
+	 * @param player    	{@link PlayerEntity} Player having powered item
+	 * @param slot 			{@code int} Slot of the targeted item
+	 * @param sourceStorage {@link EnergyStorage} EnergyStorage to output from
+	 * @param maxOutput 	{@code int} Maximum output rate of powered item
+	 * @param filter    	{@link Predicate} Filter for items to output to
+	 * @return 				The actual amount of energy transferred, can be zero (0) if the targeted item does not support power input
+	 */
+	public static long transferPower(PlayerEntity player, int slot, EnergyStorage sourceStorage, long maxOutput, Predicate<ItemStack> filter) {
+		PlayerInventoryStorage playerInv = PlayerInventoryStorage.of(player);
+
+		ItemStack invStack = player.getInventory().getStack(slot);
+
+		if (invStack.isEmpty() || !filter.test(invStack)) {
+			return 0;
+		}
+
+		EnergyStorage receiverStorage = ContainerItemContext.ofPlayerSlot(player, playerInv.getSlots().get(slot)).find(EnergyStorage.ITEM);
+
+		return EnergyStorageUtil.move(
+			sourceStorage,
+			receiverStorage,
+			maxOutput,
+			null
+		);
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,16 @@ repositories {
         content {
             // Trinkets dependency
             includeGroup "io.github.onyxstudios.Cardinal-Components-API"
+            includeGroup "dev.onyxstudios.cardinal-components-api"
+        }
+    }
+    // Needed because of an error in the POM file in the Trinkets implementation
+    // See https://github.com/emilyploszaj/trinkets/issues/159
+    maven {
+        name = "TerraformersMC"
+        url = "https://maven.terraformersmc.com/"
+        content {
+            includeGroup("com.terraformersmc")
         }
     }
 	maven {
@@ -184,7 +194,7 @@ dependencies {
     include project(":RebornCore")
 
     optionalDependency "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"
-    disabledOptionalDependency "com.github.emilyploszaj:trinkets:${project.trinkets_version}"
+    optionalDependency "com.github.emilyploszaj:trinkets:${project.trinkets_version}"
     disabledOptionalDependency "net.oskarstrom:DashLoader:${project.dashloader_version}"
 
     // Use groovy for datagen/gametest, if you are copying this you prob dont want it.
@@ -304,8 +314,10 @@ task renameCrowdin(type: Copy, dependsOn: ['crowdin', 'cleanCrowdin']){
 	}
 }
 
-import groovy.json.JsonSlurper
+
 import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import groovy.util.XmlSlurper
 
 task fixTranslations(dependsOn: ['renameCrowdin']) {
     description "Remove all translations that do not have an entry, ensures that minecraft falls back to EN_US over writing out an empty string"
@@ -321,7 +333,8 @@ task fixTranslations(dependsOn: ['renameCrowdin']) {
 	}
 }
 
-import groovy.util.XmlSlurper
+
+import org.kohsuke.github.GHReleaseBuilder
 
 curseforge {
 	if (ENV.CURSEFORGE_API_KEY) {
@@ -360,7 +373,7 @@ def getBranch() {
 	return "unknown"
 }
 
-import org.kohsuke.github.GHReleaseBuilder
+
 import org.kohsuke.github.GitHub
 
 task github(dependsOn: remapJar) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,5 @@ org.gradle.jvmargs=-Xmx2G
 # Dependencies
     energy_version=2.2.0
     rei_version=8.0.438
-    trinkets_version=3.0.2
+    trinkets_version=3.3.0
     dashloader_version=2.0

--- a/src/main/java/techreborn/items/armor/BatpackItem.java
+++ b/src/main/java/techreborn/items/armor/BatpackItem.java
@@ -90,6 +90,12 @@ public class BatpackItem extends ArmorItem implements RcEnergyItem, Trinket {
 		if (worldIn.isClient) {
 			return;
 		}
+
+		// vanilla default for chest inventory slot
+		if (itemSlot != 2) {
+			return;
+		}
+
 		if (entityIn instanceof PlayerEntity) {
 			ItemUtils.distributePowerToInventory((PlayerEntity) entityIn, stack, tier.getMaxOutput());
 		}

--- a/src/main/java/techreborn/items/armor/BatpackItem.java
+++ b/src/main/java/techreborn/items/armor/BatpackItem.java
@@ -24,22 +24,30 @@
 
 package techreborn.items.armor;
 
+import dev.emi.trinkets.api.SlotReference;
+import dev.emi.trinkets.api.Trinket;
+import dev.emi.trinkets.api.TrinketsApi;
+import net.fabricmc.fabric.api.transfer.v1.context.ContainerItemContext;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ArmorItem;
 import net.minecraft.item.ArmorMaterial;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.world.World;
 import reborncore.common.powerSystem.RcEnergyItem;
 import reborncore.common.powerSystem.RcEnergyTier;
 import reborncore.common.util.ItemUtils;
+import team.reborn.energy.api.EnergyStorage;
 import techreborn.TechReborn;
 import techreborn.utils.InitUtils;
 
-public class BatpackItem extends ArmorItem implements RcEnergyItem {
+public class BatpackItem extends ArmorItem implements RcEnergyItem, Trinket {
 
 	public final int maxCharge;
 	public final RcEnergyTier tier;
@@ -48,6 +56,32 @@ public class BatpackItem extends ArmorItem implements RcEnergyItem {
 		super(material, EquipmentSlot.CHEST, new Settings().group(TechReborn.ITEMGROUP).maxCount(1).maxDamage(-1));
 		this.maxCharge = maxCharge;
 		this.tier = tier;
+		registerTrinket();
+	}
+
+	//Trinket
+	@Override
+	public void tick(ItemStack stack, SlotReference slot, LivingEntity entity) {
+		if (entity instanceof ServerPlayerEntity) {
+
+			EnergyStorage sourceStorage = ContainerItemContext.withInitial(stack).find(EnergyStorage.ITEM);
+
+			ServerPlayerEntity player = (ServerPlayerEntity) entity;
+
+			for (int i = 0; i < player.getInventory().size(); i++) {
+
+				long amountBefore = sourceStorage.getAmount();
+
+				long accepted = ItemUtils.transferPower(player, i, sourceStorage, tier.getMaxOutput(), (itemStack) -> true );
+
+				long expectedAfter = amountBefore - accepted;
+
+				if (amountBefore != expectedAfter) {
+					((BatpackItem) stack.getItem()).setStoredEnergy(stack, expectedAfter);
+				}
+			}
+
+		}
 	}
 
 	// Item
@@ -103,5 +137,12 @@ public class BatpackItem extends ArmorItem implements RcEnergyItem {
 	@Override
 	public int getItemBarStep(ItemStack stack) {
 		return ItemUtils.getPowerForDurabilityBar(stack);
+	}
+
+	private void registerTrinket() {
+		// Ensures that trinkets are only registered if the mod is installed
+		if (FabricLoader.getInstance().isModLoaded("trinkets")) {
+			TrinketsApi.registerTrinket(this, this);
+		}
 	}
 }

--- a/src/main/resources/data/trinkets/entities/techreborn.json
+++ b/src/main/resources/data/trinkets/entities/techreborn.json
@@ -1,0 +1,8 @@
+{
+	"entities": [
+		"player"
+	],
+	"slots": [
+		"chest/back"
+	]
+}

--- a/src/main/resources/data/trinkets/tags/items/chest/back.json
+++ b/src/main/resources/data/trinkets/tags/items/chest/back.json
@@ -1,0 +1,7 @@
+{
+	"replace": false,
+	"values": [
+		"techreborn:lithium_ion_batpack",
+		"techreborn:lapotronic_orbpack"
+	]
+}


### PR DESCRIPTION
* Added support for wearing BatpackItems in the 'back' trinket slot on the chest. This frees up an additional space for regular armor.

Closes #2775 

Also added a restriction on when the BatpackItem can output power. In 1.18.1 it can output if it is in any slot in a players inventory. I propose that it should only work when in the chest slot (or Trinkets chest/back slot)

Final notice: I am unsure about how to correctly handle the dependency for the Trinkets mod. I have to make changes to the `build.gradle` file to be able to run the mod. I fear that we now have a dependency on the Trinkets mod. Feel free to suggest alternatives or commit a fix if this is a problem.

---
### Notes
~~|The closest I have gotten to it working is inserting energy into the item, but not extracting from the portable battery pack itself.~~
~~The version I have committed, throws IllegalArgumentException, when you place a BatpackItem into the trinket slot, because It cannot find it in the players inventory.~~

~~To partially fix this replace~~
~~`EnergyStorage sourceStorage = ContainerItemContext.ofPlayerSlot(player, sourceSlot).find(EnergyStorage.ITEM);`~~
~~with~~
~~`EnergyStorage sourceStorage = ContainerItemContext.withInitial(itemStack).find(EnergyStorage.ITEM);`~~

~~However this causes the BatpackItems to never lose any energy. (I just realised, I may have been to tired. It clearly says that `withInitial` does not return the mutable stack)~~

After a good nights sleep, I managed to get a working prototype

~~I would probably do some refactoring to eliminate duplicate code blocks before marking this ready for review~~

~~I submit this PR as a draft, and welcome suggestions or further commits that will fix the last issues.~~

Feel free to leave some feedback