### PR TITLE
Dispenser Scrap Box related bug fix 

### DIFF
--- a/src/main/java/techreborn/api/recipe/ScrapboxRecipeCrafter.java
+++ b/src/main/java/techreborn/api/recipe/ScrapboxRecipeCrafter.java
@@ -24,6 +24,7 @@
 
 package techreborn.api.recipe;
 
+import com.google.common.collect.ImmutableList;
 import net.minecraft.block.entity.BlockEntity;
 import reborncore.common.crafting.RebornRecipe;
 import reborncore.common.recipes.RecipeCrafter;
@@ -36,6 +37,7 @@ import java.util.List;
  * @author drcrazy
  */
 public class ScrapboxRecipeCrafter extends RecipeCrafter {
+	private static ImmutableList<RebornRecipe> RecipeListCache = null;
 
 	/**
 	 * @param parent      {@link BlockEntity} Tile having this crafter
@@ -49,7 +51,10 @@ public class ScrapboxRecipeCrafter extends RecipeCrafter {
 
 	@Override
 	public void updateCurrentRecipe() {
-		List<RebornRecipe> scrapboxRecipeList = ModRecipes.SCRAPBOX.getRecipes(blockEntity.getWorld());
+		if(RecipeListCache == null){
+			RecipeListCache = ImmutableList.copyOf(ModRecipes.SCRAPBOX.getRecipes(blockEntity.getWorld()));
+		}
+		List<RebornRecipe> scrapboxRecipeList = RecipeListCache;
 		if (scrapboxRecipeList.isEmpty()) {
 			setCurrentRecipe(null);
 			return;

--- a/src/main/java/techreborn/init/TRDispenserBehavior.java
+++ b/src/main/java/techreborn/init/TRDispenserBehavior.java
@@ -59,7 +59,7 @@ public class TRDispenserBehavior {
 				public ItemStack dispenseSilently(BlockPointer pointer, ItemStack stack) {
 					List<RebornRecipe> scrapboxRecipeList = ModRecipes.SCRAPBOX.getRecipes(pointer.getWorld());
 					int random = new Random().nextInt(scrapboxRecipeList.size());
-					ItemStack out = scrapboxRecipeList.get(random).getOutputs().get(0);
+					ItemStack out = scrapboxRecipeList.get(random).getOutputs().get(0).copy();
 					stack.split(1);
 
 					Direction facing = pointer.getBlockState().get(DispenserBlock.FACING);


### PR DESCRIPTION
It used Itemstack object itself instead of copy, and called decrement(1), which made original recipe's item object reference air, and sent it to client as air, and caused recipeSerde exception.

