### PR TITLE
Spread out slot transfer actions & caching

### DIFF
--- a/RebornCore/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
+++ b/RebornCore/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
@@ -68,6 +68,7 @@ import reborncore.common.util.Tank;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Random;
 
 /**
  * Created by modmuss50 on 04/11/2016.
@@ -78,14 +79,15 @@ public class MachineBaseBlockEntity extends BlockEntity implements BlockEntityTi
 	private SlotConfiguration slotConfiguration;
 	public FluidConfiguration fluidConfiguration;
 	private RedstoneConfiguration redstoneConfiguration;
-	private int lastTickedSync = 0;
 	public InventoryStorage inventoryStorage = null;
 	private BlockApiCache<Storage<ItemVariant>, Direction>[] inventoryCacheArray = new BlockApiCache[6];
 	
 	public boolean renderMultiblock = false;
 
 	private int tickTime = 0;
-
+	private boolean toggle = false;
+	private int toggleTick = 0;
+	
 	/**
 	 * <p>
 	 *  This is used to change the speed of the crafting operation.
@@ -126,8 +128,7 @@ public class MachineBaseBlockEntity extends BlockEntity implements BlockEntityTi
 	public void writeMultiblock(MultiblockWriter writer) {}
 
 	public void syncWithAll() {
-		if (world == null || world.isClient|| tickTime < lastTickedSync + 20) { return; }
-		lastTickedSync = tickTime;
+		if (world == null || world.isClient) { return; }
 		NetworkManager.sendToTracking(ClientBoundPackets.createCustomDescriptionPacket(this), this);
 	}
 
@@ -144,6 +145,7 @@ public class MachineBaseBlockEntity extends BlockEntity implements BlockEntityTi
 		}
 		redstoneConfiguration.refreshCache();
 		inventoryStorage = InventoryStorage.of(this, null);
+		tickTime = world == null? new Random().nextInt(20) : world.random.nextInt(20);
 	}
 
 	@Nullable
@@ -159,7 +161,20 @@ public class MachineBaseBlockEntity extends BlockEntity implements BlockEntityTi
 		writeNbt(compound);
 		return compound;
 	}
-
+	
+	public int getTickTime(){
+		return this.tickTime;
+	}
+	
+	public boolean getToggle(){
+		if (toggleTick == this.tickTime){
+			return toggle;
+		}
+		toggleTick = this.tickTime;
+		this.toggle = !this.toggle;
+		return toggle;
+	}
+	
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
 		if (tickTime == 0) {

--- a/RebornCore/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
+++ b/RebornCore/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
@@ -128,6 +128,7 @@ public class MachineBaseBlockEntity extends BlockEntity implements BlockEntityTi
 	public void syncWithAll() {
 		if (world == null || world.isClient|| tickTime < lastTickedSync + 20) { return; }
 		lastTickedSync = tickTime;
+		NetworkManager.sendToTracking(ClientBoundPackets.createCustomDescriptionPacket(this), this);
 	}
 
 	public void onLoad() {

--- a/RebornCore/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
+++ b/RebornCore/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
@@ -24,8 +24,11 @@
 
 package reborncore.common.blockentity;
 
+import net.fabricmc.fabric.api.lookup.v1.block.BlockApiCache;
 import net.fabricmc.fabric.api.transfer.v1.item.InventoryStorage;
-
+import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
@@ -38,6 +41,7 @@ import net.minecraft.inventory.SidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -76,6 +80,8 @@ public class MachineBaseBlockEntity extends BlockEntity implements BlockEntityTi
 	private RedstoneConfiguration redstoneConfiguration;
 	private int lastTickedSync = 0;
 	public InventoryStorage inventoryStorage = null;
+	private BlockApiCache<Storage<ItemVariant>, Direction>[] inventoryCacheArray = new BlockApiCache[6];
+	
 	public boolean renderMultiblock = false;
 
 	private int tickTime = 0;
@@ -250,6 +256,13 @@ public class MachineBaseBlockEntity extends BlockEntity implements BlockEntityTi
 		return Optional.empty();
 	}
 
+	public Storage<ItemVariant> getItemStorage(Direction direction){
+		if(this.inventoryCacheArray[direction.ordinal()] == null){
+			this.inventoryCacheArray[direction.ordinal()] = BlockApiCache.create(ItemStorage.SIDED, (ServerWorld)this.world, this.pos.offset(direction));
+		}
+		return this.inventoryCacheArray[direction.ordinal()].find(direction.getOpposite());
+	}
+	
 	@Override
 	public void readNbt(NbtCompound tagCompound) {
 		super.readNbt(tagCompound);

--- a/RebornCore/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
+++ b/RebornCore/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
@@ -127,7 +127,7 @@ public class MachineBaseBlockEntity extends BlockEntity implements BlockEntityTi
 
 	public void syncWithAll() {
 		if (world == null || world.isClient|| tickTime < lastTickedSync + 20) { return; }
-		NetworkManager.sendToTracking(ClientBoundPackets.createCustomDescriptionPacket(this), this);
+		lastTickedSync = tickTime;
 	}
 
 	public void onLoad() {

--- a/RebornCore/src/main/java/reborncore/common/blockentity/SlotConfiguration.java
+++ b/RebornCore/src/main/java/reborncore/common/blockentity/SlotConfiguration.java
@@ -76,7 +76,7 @@ public class SlotConfiguration implements NBTSerializable {
 				}
 			}
 		}
-		if (!machineBase.getWorld().isClient && machineBase.getWorld().getTickTime() % machineBase.slotTransferSpeed() == 0) {
+		if (!machineBase.getWorld().isClient && machineBase.getTickTime() % machineBase.slotTransferSpeed() == 0) {
 			getSlotDetails().forEach(slotConfigHolder -> slotConfigHolder.handleItemIO(machineBase));
 		}
 	}

--- a/RebornCore/src/main/java/reborncore/common/blockentity/SlotConfiguration.java
+++ b/RebornCore/src/main/java/reborncore/common/blockentity/SlotConfiguration.java
@@ -25,13 +25,18 @@
 package reborncore.common.blockentity;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.fabricmc.fabric.api.lookup.v1.block.BlockApiCache;
 import net.fabricmc.fabric.api.transfer.v1.item.InventoryStorage;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageUtil;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.StringNbtReader;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import org.apache.commons.lang3.Validate;
 import org.jetbrains.annotations.NotNull;
@@ -46,9 +51,15 @@ import java.util.stream.Collectors;
 public class SlotConfiguration implements NBTSerializable {
 
 	List<SlotConfigHolder> slotDetails = new ArrayList<>();
-
+	private static final HashMap<Map.Entry<ServerWorld, BlockPos>, BlockApiCache<Storage<ItemVariant>, Direction>> sidedStorageCache = new HashMap<>();
 	@Nullable
 	Inventory inventory;
+
+	public static Storage<ItemVariant> getOrCache(ServerWorld world, BlockPos pos, Direction direction){
+		return sidedStorageCache.computeIfAbsent(Map.entry(world, pos),
+			entry-> BlockApiCache.create(
+				ItemStorage.SIDED, entry.getKey(), entry.getValue())).find(direction);
+	}
 
 	public SlotConfiguration(RebornInventory<?> inventory) {
 		this.inventory = inventory;
@@ -177,18 +188,29 @@ public class SlotConfiguration implements NBTSerializable {
 			if (!input && !output) {
 				return;
 			}
-			getAllSides().stream()
-				.filter(config -> config.getSlotIO().getIoConfig() != ExtractConfig.NONE)
-				.forEach(config -> {
-					if (input && config.getSlotIO().getIoConfig() == ExtractConfig.INPUT) {
-						config.handleItemInput(machineBase);
-					}
-					if (output && config.getSlotIO().getIoConfig() == ExtractConfig.OUTPUT) {
-						config.handleItemOutput(machineBase);
-					}
-				});
+			if(machineBase.getWorld().getTime() % (2L * machineBase.slotTransferSpeed()) == 0) {
+				handleItemInput(machineBase);
+			}
+			else {
+				handleItemOutput(machineBase);
+			}
 		}
-
+		private void handleItemInput(MachineBaseBlockEntity machineBase) {
+			if (!input) {
+				return;
+			}
+			getAllSides().stream()
+				.filter(config -> config.getSlotIO().getIoConfig() == ExtractConfig.INPUT)
+				.forEach(config -> config.handleItemInput(machineBase));
+		}
+		private void handleItemOutput(MachineBaseBlockEntity machineBase) {
+			if (!output) {
+				return;
+			}
+			getAllSides().stream()
+				.filter(config -> config.getSlotIO().getIoConfig() == ExtractConfig.OUTPUT)
+				.forEach(config -> config.handleItemOutput(machineBase));
+		}
 		public boolean autoInput() {
 			return input;
 		}
@@ -289,12 +311,11 @@ public class SlotConfiguration implements NBTSerializable {
 			if (targetStack.getMaxCount() == targetStack.getCount()) {
 				return;
 			}
-
 			StorageUtil.move(
-					ItemStorage.SIDED.find(machineBase.getWorld(), machineBase.getPos().offset(side), side.getOpposite()),
-					InventoryStorage.of(machineBase, null).getSlot(slotID),
+				getOrCache((ServerWorld)machineBase.getWorld(), machineBase.getPos().offset(side), side.getOpposite()),
+				machineBase.inventoryStorage.getSlot(slotID),
 					iv -> true,
-					4, // Move up to 4 per tick.
+					64, // Move up to 256 per tick.
 					null
 			);
 		}
@@ -307,10 +328,10 @@ public class SlotConfiguration implements NBTSerializable {
 			}
 
 			StorageUtil.move(
-					InventoryStorage.of(machineBase, null).getSlot(slotID),
-					ItemStorage.SIDED.find(machineBase.getWorld(), machineBase.getPos().offset(side), side.getOpposite()),
+					machineBase.inventoryStorage.getSlot(slotID),
+					getOrCache((ServerWorld)machineBase.getWorld(), machineBase.getPos().offset(side), side.getOpposite()),
 					iv -> true,
-					Long.MAX_VALUE,
+					64,
 					null
 			);
 		}

--- a/RebornCore/src/main/java/reborncore/common/blockentity/SlotConfiguration.java
+++ b/RebornCore/src/main/java/reborncore/common/blockentity/SlotConfiguration.java
@@ -76,7 +76,7 @@ public class SlotConfiguration implements NBTSerializable {
 				}
 			}
 		}
-		if (!machineBase.getWorld().isClient && machineBase.getWorld().getTime() % machineBase.slotTransferSpeed() == 0) {
+		if (!machineBase.getWorld().isClient && machineBase.getWorld().getTickTime() % machineBase.slotTransferSpeed() == 0) {
 			getSlotDetails().forEach(slotConfigHolder -> slotConfigHolder.handleItemIO(machineBase));
 		}
 	}
@@ -181,7 +181,7 @@ public class SlotConfiguration implements NBTSerializable {
 			if (!input && !output) {
 				return;
 			}
-			if(machineBase.getWorld().getTime() % (2L * machineBase.slotTransferSpeed()) == 0) {
+			if(machineBase.getToggle()) {
 				handleItemInput(machineBase);
 			}
 			else {

--- a/RebornCore/src/main/java/reborncore/common/blockentity/SlotConfiguration.java
+++ b/RebornCore/src/main/java/reborncore/common/blockentity/SlotConfiguration.java
@@ -51,15 +51,8 @@ import java.util.stream.Collectors;
 public class SlotConfiguration implements NBTSerializable {
 
 	List<SlotConfigHolder> slotDetails = new ArrayList<>();
-	private static final HashMap<Map.Entry<ServerWorld, BlockPos>, BlockApiCache<Storage<ItemVariant>, Direction>> sidedStorageCache = new HashMap<>();
 	@Nullable
 	Inventory inventory;
-
-	public static Storage<ItemVariant> getOrCache(ServerWorld world, BlockPos pos, Direction direction){
-		return sidedStorageCache.computeIfAbsent(Map.entry(world, pos),
-			entry-> BlockApiCache.create(
-				ItemStorage.SIDED, entry.getKey(), entry.getValue())).find(direction);
-	}
 
 	public SlotConfiguration(RebornInventory<?> inventory) {
 		this.inventory = inventory;
@@ -312,7 +305,7 @@ public class SlotConfiguration implements NBTSerializable {
 				return;
 			}
 			StorageUtil.move(
-				getOrCache((ServerWorld)machineBase.getWorld(), machineBase.getPos().offset(side), side.getOpposite()),
+				machineBase.getItemStorage(side),
 				machineBase.inventoryStorage.getSlot(slotID),
 					iv -> true,
 					64, // Move up to 256 per tick.
@@ -329,7 +322,7 @@ public class SlotConfiguration implements NBTSerializable {
 
 			StorageUtil.move(
 					machineBase.inventoryStorage.getSlot(slotID),
-					getOrCache((ServerWorld)machineBase.getWorld(), machineBase.getPos().offset(side), side.getOpposite()),
+					machineBase.getItemStorage(side),
 					iv -> true,
 					64,
 					null

--- a/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
@@ -120,6 +120,7 @@ public class StorageUnitBaseBlockEntity extends MachineBaseBlockEntity implement
 	
 	@Override
 	public void syncWithAll() {
+		if (world.isClient) return;
 		NetworkManager.sendToTracking(ClientBoundPackets.createCustomDescriptionPacket(this), this);
 	}
 	public boolean canModifyLocking() {

--- a/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
@@ -46,6 +46,8 @@ import reborncore.api.IToolDrop;
 import reborncore.api.blockentity.InventoryProvider;
 import reborncore.client.screen.builder.ScreenHandlerBuilder;
 import reborncore.common.blockentity.MachineBaseBlockEntity;
+import reborncore.common.network.ClientBoundPackets;
+import reborncore.common.network.NetworkManager;
 import reborncore.common.screen.BuiltScreenHandler;
 import reborncore.common.screen.BuiltScreenHandlerProvider;
 import reborncore.common.util.ItemUtils;

--- a/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
@@ -46,8 +46,6 @@ import reborncore.api.IToolDrop;
 import reborncore.api.blockentity.InventoryProvider;
 import reborncore.client.screen.builder.ScreenHandlerBuilder;
 import reborncore.common.blockentity.MachineBaseBlockEntity;
-import reborncore.common.network.ClientBoundPackets;
-import reborncore.common.network.NetworkManager;
 import reborncore.common.screen.BuiltScreenHandler;
 import reborncore.common.screen.BuiltScreenHandlerProvider;
 import reborncore.common.util.ItemUtils;
@@ -118,11 +116,6 @@ public class StorageUnitBaseBlockEntity extends MachineBaseBlockEntity implement
 		syncWithAll();
 	}
 	
-	@Override
-	public void syncWithAll() {
-		if (world.isClient) return;
-		NetworkManager.sendToTracking(ClientBoundPackets.createCustomDescriptionPacket(this), this);
-	}
 	public boolean canModifyLocking() {
 		// Can always be unlocked
 		if (isLocked()) {

--- a/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
@@ -115,7 +115,11 @@ public class StorageUnitBaseBlockEntity extends MachineBaseBlockEntity implement
 		lockedItemStack = value ? stack : ItemStack.EMPTY;
 		syncWithAll();
 	}
-
+	
+	@Override
+	public void syncWithAll() {
+		NetworkManager.sendToTracking(ClientBoundPackets.createCustomDescriptionPacket(this), this);
+	}
 	public boolean canModifyLocking() {
 		// Can always be unlocked
 		if (isLocked()) {


### PR DESCRIPTION
**!! It requires reviews**
I was using this for months so it *should* be okay tho...

Changes :
    Transfer Behavior : its transfer speed is actually equal, but it does not instantly transfers items. 
        -Now it inputs items then outputs items in separate tick, so it efficiently spreads out mspt.

    Caches InventoryStorage.of
        -Should not affect anything and just 2% performance boost
    Prevent SyncWithAll being spammed
        -reduces packets... but seems there's more packet spam issues, it generates thousands of packets...


Performance boosts:
         Tested with 670 storage units working constantly, reduced 4.6mspt -> 2.67mspt