### PR TITLE
Rebalanced gunpowder and uu matter

### DIFF
--- a/src/main/resources/data/techreborn/advancements/recipes/extractor/gunpowder.json
+++ b/src/main/resources/data/techreborn/advancements/recipes/extractor/gunpowder.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+	"recipes": [
+	  "techreborn:extractor/gunpowder"
+	]
+  },
+  "criteria": {
+	"has_tnt": {
+	  "trigger": "minecraft:inventory_changed",
+	  "conditions": {
+		"items": [
+		  {
+			"items": ["minecraft:tnt"]
+		  }
+		]
+	  }
+	},
+	"has_the_recipe": {
+	  "trigger": "minecraft:recipe_unlocked",
+	  "conditions": {
+		"recipe": "techreborn:extractor/gunpowder"
+	  }
+	}
+  },
+  "requirements": [
+	[
+	  "has_tnt",
+	  "has_the_recipe"
+	]
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/crafting_table/uu_matter/tnt.json
+++ b/src/main/resources/data/techreborn/recipes/crafting_table/uu_matter/tnt.json
@@ -11,6 +11,6 @@
     }
   },
   "result": {
-    "item": "minecraft:gunpowder"
+    "item": "minecraft:tnt"
   }
 }

--- a/src/main/resources/data/techreborn/recipes/extractor/gunpowder.json
+++ b/src/main/resources/data/techreborn/recipes/extractor/gunpowder.json
@@ -1,0 +1,16 @@
+{
+  "type": "techreborn:extractor",
+  "power": 10,
+  "time": 300,
+  "ingredients": [
+	{
+	  "item": "minecraft:tnt"
+	}
+  ],
+  "results": [
+	{
+	  "item": "minecraft:gunpowder",
+	  "count": 2
+	}
+  ]
+}


### PR DESCRIPTION
Gunpowder costs 3 uu matter and iridium ore costs 6. A stark contrast. Now, if you have a creeper farm, you don't need the recipe. If you don't have a creeper farm, this is very expensive, because it means 15 uu matter for one tnt block, or 120 uu matter for one iridium alloy plate explosion. Too much!

So this PR changes the recipe for gunpowder to tnt and adds an extractor recipe for gunpowder from tnt. So now 1 gunpowder equals 1.5 uu matter and one iridium alloy plate explosion equals 24 uu matter, or 36 uu matter if we count the iridium ore as well.

PS: untested, but unless I did a typo should work