### PR TITLE
Added elytra recipe

### DIFF
--- a/src/main/resources/data/techreborn/advancements/recipes/assembling_machine/elytra.json
+++ b/src/main/resources/data/techreborn/advancements/recipes/assembling_machine/elytra.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+	"recipes": [
+	  "techreborn:assembling_machine/elytra"
+	]
+  },
+  "criteria": {
+	"has_end_rod": {
+	  "trigger": "minecraft:inventory_changed",
+	  "conditions": {
+		"items": [
+		  {
+			"items": ["minecraft:end_rod"]
+		  }
+		]
+	  }
+	},
+	"has_the_recipe": {
+	  "trigger": "minecraft:recipe_unlocked",
+	  "conditions": {
+		"recipe": "techreborn:assembling_machine/elytra"
+	  }
+	}
+  },
+  "requirements": [
+	[
+	  "has_end_rod",
+	  "has_the_recipe"
+	]
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/assembling_machine/elytra.json
+++ b/src/main/resources/data/techreborn/recipes/assembling_machine/elytra.json
@@ -1,0 +1,20 @@
+{
+  "type": "techreborn:assembling_machine",
+  "power": 20,
+  "time": 500,
+  "ingredients": [
+    {
+      "item": "minecraft:phantom_membrane",
+      "count": 16
+    },
+    {
+      "item": "minecraft:end_rod",
+      "count": 3
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:elytra"
+    }
+  ]
+}


### PR DESCRIPTION
16 Phantom Membrane + 3 End Rods -> Elytra via Assembly Machine

Reasoning: End Rods gate the recipe behind the End, at least in Standalone. Once one Elytra is obtained in Vanilla, all additional ones are easy to get and only time consuming, but not challenging like the first one. This recipe allows the player to save some time of that, by slaying phantoms instead. With Looting III and Smite V that is done quickly, but such a player would probably also don't have too much of a problem throwing an enderpearl on a flying ship. For others it takes more time, I would say roughly equivalent to finding an end city and climb it. So basically we are taking away the challenge of the city for players who built an assembly machine. For others it might be faster just to fly to a new Elytra, so I recon this is a very balanced recipe that fits well into TR as standalone and also makes TR more attractive in mod packs.

Thoughts?