### PR TITLE
Added shulker shell recipe

### DIFF
--- a/src/main/resources/data/techreborn/advancements/recipes/crafting_table/parts/shulker_shell.json
+++ b/src/main/resources/data/techreborn/advancements/recipes/crafting_table/parts/shulker_shell.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+	"recipes": [
+	  "techreborn:crafting_table/parts/shulker_shell"
+	]
+  },
+  "criteria": {
+	"has_purpur_pillar": {
+	  "trigger": "minecraft:inventory_changed",
+	  "conditions": {
+		"items": [
+		  {
+			"items": ["minecraft:purpur_pillar"]
+		  }
+		]
+	  }
+	},
+	"has_the_recipe": {
+	  "trigger": "minecraft:recipe_unlocked",
+	  "conditions": {
+		"recipe": "techreborn:crafting_table/parts/shulker_shell"
+	  }
+	}
+  },
+  "requirements": [
+	[
+	  "has_purpur_pillar",
+	  "has_the_recipe"
+	]
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/crafting_table/parts/shulker_shell.json
+++ b/src/main/resources/data/techreborn/recipes/crafting_table/parts/shulker_shell.json
@@ -1,0 +1,25 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "BPB",
+    "BTB",
+    " E "
+  ],
+  "key": {
+    "B": {
+      "item": "minecraft:purpur_block"
+    },
+	"E": {
+	  "tag": "c:endstone_small_dusts"
+	},
+    "P": {
+      "item": "minecraft:purpur_pillar"
+    },
+    "T": {
+      "tag": "c:enderpearl_dusts"
+    }
+  },
+  "result": {
+    "item": "item:shulker_shell"
+  }
+}


### PR DESCRIPTION
4 Purpur blocks + purpur pillar + enderpearl dust + small endstone dust -> shulker shell via crafting table

Reasoning: Purpur blocks gate the recipe behind the End, at least in Standalone. Now Shulkers are a bit more of a hassle to defeat than elytras, but if you want many boxes, it is very grindy, possibly with several end cities. This recipe shifts the grinding towards making chorus fruit. You still need 2 enderpearls for one shulker box, so I think this is balanced and improves overall game experience. In addition, it makes shulker shells available in peaceful mode.

Thoughts?