### PR TITLE
Added red sand -> soul sand via blast furnace

### DIFF
--- a/src/main/resources/data/techreborn/advancements/recipes/blast_furnace/soul_sand.json
+++ b/src/main/resources/data/techreborn/advancements/recipes/blast_furnace/soul_sand.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+	"recipes": [
+	  "techreborn:blast_furnace/soul_sand"
+	]
+  },
+  "criteria": {
+	"has_red_sand": {
+	  "trigger": "minecraft:inventory_changed",
+	  "conditions": {
+		"items": [
+		  {
+			"items": ["minecraft:red_sand"]
+		  }
+		]
+	  }
+	},
+	"has_the_recipe": {
+	  "trigger": "minecraft:recipe_unlocked",
+	  "conditions": {
+		"recipe": "techreborn:blast_furnace/soul_sand"
+	  }
+	}
+  },
+  "requirements": [
+	[
+	  "has_red_sand",
+	  "has_the_recipe"
+	]
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/blast_furnace/soul_sand.json
+++ b/src/main/resources/data/techreborn/recipes/blast_furnace/soul_sand.json
@@ -1,0 +1,23 @@
+{
+  "type": "techreborn:blast_furnace",
+  "power": 128,
+  "time": 500,
+  "heat": 3000,
+  "ingredients": [
+    {
+      "item": "minecraft:red_sand",
+	  "count": 8
+    },
+	{
+	  "fluid": "techreborn:carbon",
+	  "holder": "techreborn:cell",
+	  "count": 5
+	}
+  ],
+  "results": [
+    {
+      "item": "minecraft:soul_sand",
+	  "count": 8
+    }
+  ]
+}


### PR DESCRIPTION
Reasoning: Red sand is considerably rare, at least rarer than soul sand, unless crafted with netherrack dust. Smelting time is long. I think this is a reasonable alternative to the player farming soulsand, without making the other option worthless.

Since rare sand can be obtained in overworld, this technically allows players to get soulsand without going to the nether. But soulsand centrifuges to oil and salpeter, the latter only to be used to create gunpowder, and both these things are/should be in overworld anyway. Also the high required heat means players have to get industrial casings first anyway.