### PR TITLE
Fix KIBE Entangled Bucket bug & Creative tank is creative

### DIFF
--- a/src/main/java/techreborn/blockentity/storage/fluid/TankUnitBaseBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/fluid/TankUnitBaseBlockEntity.java
@@ -108,17 +108,27 @@ public class TankUnitBaseBlockEntity extends MachineBaseBlockEntity implements I
 			return;
 		}
 
-		if ((canDrainTransfer() && FluidUtils.drainContainers(tank, inventory, 0, 1))
-				|| FluidUtils.fillContainers(tank, inventory, 0, 1)) {
-
-			if (type == TRContent.TankUnit.CREATIVE) {
-				if (!tank.isEmpty() && !tank.isFull()) {
-					tank.setFluidAmount(tank.getFluidValueCapacity());
-				}
+		if (canDrainTransfer() && FluidUtils.isContainer(inventory.getStack(0))) {
+			boolean didSomething = false;
+			if(FluidUtils.drainContainers(tank, inventory, 0, 1)){
+				didSomething = true;
 			}
-			syncWithAll();
+			if(!didSomething && FluidUtils.fillContainers(tank, inventory, 0, 1)){
+				didSomething = true;
+			}
+			if(didSomething){
+				if(inventory.getStack(1).isEmpty() && !inventory.getStack(0).isEmpty() && inventory.getStack(0).getCount() == 1){
+					inventory.setStack(1, inventory.getStack(0));
+					inventory.setStack(0, ItemStack.EMPTY);
+				}
+				syncWithAll();
+			}
 		}
-
+		if (type == TRContent.TankUnit.CREATIVE) {
+			if (!tank.isEmpty() && !tank.isFull()) {
+				tank.setFluidAmount(tank.getFluidValueCapacity());
+			}
+		}
 		// Void excessive fluid in creative tank (#2205)
 		if (type == TRContent.TankUnit.CREATIVE && tank.isFull()) {
 			FluidUtils.drainContainers(tank, inventory, 0, 1, true);


### PR DESCRIPTION
This has 3 fixes:
1. Move weird entangled buckets after transfer, Kibe's entangled bucket is moved to output slot after drain / fill if it can.
2. check isContainer condition before transfer.
3. Separate creative tank fill from item transfer, and make it actually creative

Fixes this : (low frame rate but its changing inventory rapidly)
![ezgif-2-baa0f78616](https://user-images.githubusercontent.com/35677394/166138014-f9ef8ca2-17eb-44cb-9408-93e82794a113.gif)
'