### PR TITLE
improved gravel grinder recipe

### DIFF
--- a/src/main/resources/data/techreborn/advancements/recipes/grinder/gravel.json
+++ b/src/main/resources/data/techreborn/advancements/recipes/grinder/gravel.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+	"recipes": [
+	  "techreborn:grinder/gravel"
+	]
+  },
+  "criteria": {
+	"has_gravel_material": {
+	  "trigger": "minecraft:inventory_changed",
+	  "conditions": {
+		"items": [
+		  {
+			"tag": "techreborn:gravel_material"
+		  }
+		]
+	  }
+	},
+	"has_the_recipe": {
+	  "trigger": "minecraft:recipe_unlocked",
+	  "conditions": {
+		"recipe": "techreborn:grinder/gravel"
+	  }
+	}
+  },
+  "requirements": [
+	[
+	  "has_gravel_material",
+	  "has_the_recipe"
+	]
+  ]
+}

--- a/src/main/resources/data/techreborn/recipes/grinder/gravel.json
+++ b/src/main/resources/data/techreborn/recipes/grinder/gravel.json
@@ -4,7 +4,7 @@
   "time": 180,
   "ingredients" : [
     {
-      "tag": "minecraft:stone_tool_materials"
+      "tag": "techreborn:gravel_material"
     }
   ],
   "results" : [

--- a/src/main/resources/data/techreborn/tags/items/gravel_material.json
+++ b/src/main/resources/data/techreborn/tags/items/gravel_material.json
@@ -1,0 +1,22 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:stone",
+    "#minecraft:stone_bricks",
+    "minecraft:smooth_stone",
+    "minecraft:cobblestone",
+    "minecraft:deepslate",
+    "minecraft:deepslate_bricks",
+    "minecraft:cracked_deepslate_bricks",
+    "minecraft:deepslate_tiles",
+    "minecraft:cracked_deepslate_tiles",
+    "minecraft:polished_deepslate",
+    "minecraft:chiseled_deepslate",
+    "minecraft:cobbled_deepslate",
+    "minecraft:blackstone",
+    "minecraft:polished_blackstone",
+    "minecraft:chiseled_polished_blackstone",
+    "minecraft:polished_blackstone_bricks",
+    "minecraft:cracked_polished_blackstone_bricks"
+  ]
+}


### PR DESCRIPTION
There is a mod that puts granite and friends into the #stone_tool_material tag, which leads to players being unable to get their dust forms, as they get gravel instead. Since this is a reasonable tag use, I decided to create a tag for gravel material instead of using the minecraft tag. Also has the effect we can use more stones, and others can add their stones to ours ;)

Tested, works. Second pair of eyes would be appreciated.