### PR TITLE
feat(recipes): support bauxite dusts from other mods

### DIFF
--- a/src/main/resources/data/techreborn/recipes/industrial_electrolyzer/bauxite_dust.json
+++ b/src/main/resources/data/techreborn/recipes/industrial_electrolyzer/bauxite_dust.json
@@ -4,7 +4,7 @@
   "time": 2000,
   "ingredients": [
     {
-      "item": "techreborn:bauxite_dust",
+      "tag": "c:bauxite_dusts",
       "count": 12
     },
     {


### PR DESCRIPTION
This PR adds support for bauxite dusts from other mods (Modern Industrialization, etc.)