### PR TITLE
Fixed #2580

### DIFF
--- a/src/datagen/groovy/techreborn/datagen/tags/TRItemTagProvider.groovy
+++ b/src/datagen/groovy/techreborn/datagen/tags/TRItemTagProvider.groovy
@@ -73,6 +73,9 @@ class TRItemTagProvider extends ItemTagProvider {
 			getOrCreateTagBuilder(plate.asTag()).add(plate.asItem())
 			getOrCreateTagBuilder(TRContent.ItemTags.PLATES).add(plate.asItem())
 		}
+		TRContent.StorageUnit.values().each {unit ->
+			getOrCreateTagBuilder(TRContent.ItemTags.STORAGE_UNITS).add(unit.asItem())
+		}
 
 		getOrCreateTagBuilder(TRContent.ItemTags.RUBBER_LOGS)
 			.add(TRContent.RUBBER_LOG.asItem())

--- a/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
@@ -382,13 +382,18 @@ public class StorageUnitBaseBlockEntity extends MachineBaseBlockEntity implement
 		if (slot != INPUT_SLOT) {
 			return false;
 		}
-		if (inputStack == ItemStack.EMPTY){
+		if (inputStack == ItemStack.EMPTY) {
 			return false;
 		}
 		// Do not allow player heads into storage due to lag. Fix #2888
-		if (inputStack.getItem() instanceof SkullItem){
+		if (inputStack.getItem() instanceof SkullItem) {
 			return false;
 		}
+		// do not allow other storage units to avoid NBT overflow. Fix #2580
+		if (inputStack.isIn(TRContent.ItemTags.STORAGE_UNITS)) {
+			return false;
+		}
+
 		if (isLocked()) {
 			return ItemUtils.isItemEqual(lockedItemStack, inputStack, true, true);
 		}

--- a/src/main/java/techreborn/init/TRContent.java
+++ b/src/main/java/techreborn/init/TRContent.java
@@ -284,6 +284,7 @@ public class TRContent {
 		public static final TagKey<Item> GEMS = TagKey.of(Registry.ITEM_KEY, new Identifier(TechReborn.MOD_ID, "gems"));
 		public static final TagKey<Item> NUGGETS = TagKey.of(Registry.ITEM_KEY, new Identifier(TechReborn.MOD_ID, "nuggets"));
 		public static final TagKey<Item> PLATES = TagKey.of(Registry.ITEM_KEY, new Identifier(TechReborn.MOD_ID, "plates"));
+		public static final TagKey<Item> STORAGE_UNITS = TagKey.of(Registry.ITEM_KEY, new Identifier(TechReborn.MOD_ID, "storage_units"));
 
 		private ItemTags() {
 		}


### PR DESCRIPTION
Disabled putting storage units into other storage units.

The overflow can still be triggered in other ways, but players must be very deliberate for that...