### PR TITLE
Fix chemical reactor concrete powder recipe

### DIFF
--- a/src/datagen/groovy/techreborn/datagen/recipes/machine/chemical_reactor/ChemicalReactorRecipesProvider.groovy
+++ b/src/datagen/groovy/techreborn/datagen/recipes/machine/chemical_reactor/ChemicalReactorRecipesProvider.groovy
@@ -85,7 +85,7 @@ class ChemicalReactorRecipesProvider extends TechRebornRecipesProvider {
 			ColoredItem.createExtendedMixingColorStream(color, false, true).forEach(pair ->
 				offerChemicalReactorRecipe {
 					ingredients color.getDye(), stack(pair.getLeft().getConcretePowder(), 8)
-					outputs stack(pair.getRight().getCarpet(), 8)
+					outputs stack(pair.getRight().getConcretePowder(), 8)
 					source pair.getLeft().getConcretePowder().toString() + "_with_" + color.getDye().toString()
 					power DYE_POWER
 					time DYE_TIME


### PR DESCRIPTION
**Description**
Fixes bug introduced in 07547df where trying to dye concrete powder in a chemical reactor results in dyed carpet instead of dyed concrete powder.

**Steps to Reproduce**
- Set up a chemical reactor
- Place 8 concrete powder in the left slot and 1 dye in the right slot
- Outputs carpet instead of concrete powder