### PR TITLE
Fix lighting rod height calculation

### DIFF
--- a/src/main/java/techreborn/blockentity/generator/LightningRodBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/generator/LightningRodBlockEntity.java
@@ -97,8 +97,8 @@ public class LightningRodBlockEntity extends PowerAcceptorBlockEntity implements
 	}
 
 	public float getLightningStrikeMultiplier() {
-		final float actualHeight = 256;
-		final float groundLevel = world.getTopPosition(Heightmap.Type.MOTION_BLOCKING, getPos()).getY();
+		final float actualHeight = world.getTopY();
+		final float groundLevel = world.getSeaLevel() + 1;
 		for (int i = pos.getY() + 1; i < actualHeight; i++) {
 			if (!isValidIronFence(i)) {
 				if (groundLevel >= i)
@@ -108,7 +108,7 @@ public class LightningRodBlockEntity extends PowerAcceptorBlockEntity implements
 				return 1.2F - got / max;
 			}
 		}
-		return 4F;
+		return 0.2F;
 	}
 
 	public boolean isValidIronFence(int y) {


### PR DESCRIPTION
The lightning rod height calculation was broken in https://github.com/TechReborn/TechReborn/commit/6b9f6cb4f8161c51876364cf70614fbf924f8aeb by replacing `world.getAverageGroundLevel()`, which returned `world.getSeaLevel() + 1` with `world.getTopPosition(Heightmap.Type.MOTION_BLOCKING, getPos()).getY()`, which returns the position of the highest block above the lightining rod + 1, making the following `if (groundLevel >= i)` check always true and making the lightning rod always work at the speed as if it's below the sea level.
This pull request brings back the original behaviour, makes it support world height > 256 and fixes an edge case when the lightning rod fences go up to max world Y, which before returned 4.0f, while it should have been 0.2f