### PR TITLE
Allow omni tool to work as wrench

### DIFF
--- a/src/main/java/techreborn/items/tool/industrial/OmniToolItem.java
+++ b/src/main/java/techreborn/items/tool/industrial/OmniToolItem.java
@@ -141,7 +141,7 @@ public class OmniToolItem extends MiningToolItem implements RcEnergyItem, IToolH
 
 	@Override
 	public boolean handleTool(ItemStack stack, BlockPos pos, World world, PlayerEntity player, Direction side, boolean damage) {
-		if (!player.getWorld().isClient && this.getStoredEnergy(stack) > 50.0) {
+		if (!player.getWorld().isClient && this.getStoredEnergy(stack) >= 5.0) {
 			this.tryUseEnergy(stack, (long) 5);
 			return true;
 		} else {

--- a/src/main/java/techreborn/items/tool/industrial/OmniToolItem.java
+++ b/src/main/java/techreborn/items/tool/industrial/OmniToolItem.java
@@ -34,7 +34,9 @@ import net.minecraft.item.Items;
 import net.minecraft.item.MiningToolItem;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import reborncore.api.IToolHandler;
 import reborncore.common.powerSystem.RcEnergyItem;
 import reborncore.common.powerSystem.RcEnergyTier;
 import reborncore.common.util.ItemUtils;
@@ -44,7 +46,7 @@ import techreborn.init.TRContent;
 import techreborn.init.TRToolMaterials;
 import techreborn.items.tool.MiningLevel;
 
-public class OmniToolItem extends MiningToolItem implements RcEnergyItem {
+public class OmniToolItem extends MiningToolItem implements RcEnergyItem, IToolHandler {
 	public final int miningLevel;
 
 	// 4M FE max charge with 1k charge rate
@@ -135,5 +137,15 @@ public class OmniToolItem extends MiningToolItem implements RcEnergyItem {
 	@Override
 	public RcEnergyTier getTier() {
 		return RcEnergyTier.EXTREME;
+	}
+
+	@Override
+	public boolean handleTool(ItemStack stack, BlockPos pos, World world, PlayerEntity player, Direction side, boolean damage) {
+		if (!player.getWorld().isClient && this.getStoredEnergy(stack) > 50.0) {
+			this.tryUseEnergy(stack, (long) 5);
+			return true;
+		} else {
+			return false;
+		}
 	}
 }

--- a/src/main/resources/data/techreborn/recipes/crafting_table/tool/omni_tool.json
+++ b/src/main/resources/data/techreborn/recipes/crafting_table/tool/omni_tool.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "D  ",
+	" WD",
     " C ",
-    "  S"
+    "S  "
   ],
   "key": {
     "D": {
@@ -14,7 +14,10 @@
     },
     "S": {
       "item": "minecraft:diamond_sword"
-    }
+    },
+	"W": {
+		"item": "techreborn:wrench"
+	}
   },
   "result": {
     "item": "techreborn:omni_tool"


### PR DESCRIPTION
Changes:
- Omni tool now implements tool handler
- Omni tool can only pick up blocks if it has more than 50 E
- Omni tool recipe now requires a wrench

This was suggested in discussion #3036