### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/src/main/java/techreborn/init/FuelRecipes.java
+++ b/src/main/java/techreborn/init/FuelRecipes.java
@@ -31,7 +31,7 @@ public class FuelRecipes {
 	public static void init() {
 		FuelRegistry registry = FuelRegistry.INSTANCE;
 
-		// Basing it off https://minecraft.gamepedia.com/Furnace/table
+		// Basing it off https://minecraft.wiki/w/Template:Smelting_table
 
 		// Rubber spam
 		registry.add(TRContent.RUBBER_BUTTON, 300);


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.