### PR TITLE
Set resin basin to empty state on harvest

### DIFF
--- a/src/main/java/techreborn/blockentity/machine/tier1/ResinBasinBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/tier1/ResinBasinBlockEntity.java
@@ -143,12 +143,18 @@ public class ResinBasinBlockEntity extends MachineBaseBlockEntity {
 	}
 
 	public ItemStack empty() {
-		int sapAmount = getSapAmount();
 		if (isFull) {
-			isFull = false;
+			int sapAmount = getSapAmount();
+
+			this.isPouring = false;
+			this.isFull = false;
+			setFullState(false);
 			setPouringState(false);
+
+			return new ItemStack(TRContent.Parts.SAP, sapAmount);
 		}
-		return new ItemStack(TRContent.Parts.SAP, sapAmount);
+
+		return new ItemStack(TRContent.Parts.SAP, 0);
 	}
 
 	@Override


### PR DESCRIPTION
When manually harvesting the Resin Basin, it's state is not updated to be empty but continues to stay full even though it is not.

This PR fixes this state mismatch.