### PR TITLE
Make Overclocker tooltips reflect reality

### DIFF
--- a/RebornCore/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
+++ b/RebornCore/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
@@ -77,6 +77,8 @@ public class MachineBaseBlockEntity extends BlockEntity implements BlockEntityTi
 	private boolean markSync = false;
 	private int tickTime = 0;
 
+	public static double SPEED_CAP = 0.99;
+
 	/**
 	 * <p>
 	 *  This is used to change the speed of the crafting operation.
@@ -351,10 +353,10 @@ public class MachineBaseBlockEntity extends BlockEntity implements BlockEntityTi
 
 	@Override
 	public void addSpeedMultiplier(double amount) {
-		if (speedMultiplier + amount <= 0.99) {
+		if (speedMultiplier + amount <= SPEED_CAP) {
 			speedMultiplier += amount;
 		} else {
-			speedMultiplier = 0.99;
+			speedMultiplier = SPEED_CAP;
 		}
 	}
 

--- a/src/main/resources/assets/techreborn/lang/en_us.json
+++ b/src/main/resources/assets/techreborn/lang/en_us.json
@@ -897,7 +897,7 @@
   "techreborn.tooltip.inventory": "Inventory",
   "techreborn.tooltip.upgrades": "Upgrades",
   "techreborn.tooltip.upgrade.speed_increase": "Time decrease",
-  "techreborn.tooltip.upgrade.energy_increase": "Energy per tick increase",
+  "techreborn.tooltip.upgrade.energy_increase": "Energy usage",
   "techreborn.tooltip.upgrade.storage_increase": "Storage increase",
   "techreborn.tooltip.upgrade.flow_increase": "Increased flow by",
   "techreborn.tooltip.alarm": "Shift right-click to change sound",


### PR DESCRIPTION
Merging this PR will fix #3196.

This PR changes the overclocker tooltips in these ways:
- The stack info is now capped at 4 upgrades.
- Increase/Decrease color is now applied at the stat rather than the explanation, what is this stat.
- Added new calculate methods to satisfy the overclocker stat special needs.
- The overclocker "Time Decrease" is now capped at 97.5% (experimentally determined by processing a recipe taking 200 seconds with 4 overclockers)
- Stats now support doubles (instead of only ints) - rounded using `NumberFormat` to ensure that the decimal point is only shown when needed.

Also added a `SPEED_CAP` constant to the `MachineBaseBlockEntity.java` - pretty weird that the cap was supposed to be 99%, not 97.5% like it is in reality.

![overclock_noshift](https://github.com/TechReborn/TechReborn/assets/125081901/825309ff-7324-4648-9388-452815549f1a)
![overclock_shift](https://github.com/TechReborn/TechReborn/assets/125081901/b5ed0c66-562a-49e5-9a08-b4fc1f9c3a2a)
![obraz](https://github.com/TechReborn/TechReborn/assets/125081901/df7ec820-55e2-4514-add3-3cb0639b771b)

