### PR TITLE
Add night vision to Quantum Helmet

### DIFF
--- a/src/client/java/techreborn/TechRebornClient.java
+++ b/src/client/java/techreborn/TechRebornClient.java
@@ -133,8 +133,8 @@ public class TechRebornClient implements ClientModInitializer {
 		KeyBindings.registerKeys();
 
 		ClientTickEvents.END_CLIENT_TICK.register(client -> {
-			while (KeyBindings.nanoSuitNightVision.wasPressed()) {
-				KeyBindings.handleNanoSuitNVToggle();
+			while (KeyBindings.suitNightVision.wasPressed()) {
+				KeyBindings.handleSuitNVToggle();
 			}
 		});
 

--- a/src/client/java/techreborn/client/keybindings/KeyBindings.java
+++ b/src/client/java/techreborn/client/keybindings/KeyBindings.java
@@ -38,17 +38,17 @@ public class KeyBindings {
 
 	public static KeyBinding config = new KeyBinding(CONFIG, GLFW.GLFW_KEY_P, CATEGORY);
 
-	public static KeyBinding nanoSuitNightVision;
+	public static KeyBinding suitNightVision;
 
 	public static void registerKeys() {
-		nanoSuitNightVision = KeyBindingHelper.registerKeyBinding(
-			new KeyBinding("key.techreborn.nanoSuitNightVision",
+		suitNightVision = KeyBindingHelper.registerKeyBinding(
+			new KeyBinding("key.techreborn.suitNightVision",
 				InputUtil.Type.KEYSYM,
 				GLFW.GLFW_KEY_N,
 				CATEGORY));
 	}
 
-	public static void handleNanoSuitNVToggle() {
+	public static void handleSuitNVToggle() {
 		ClientNetworkManager.sendToServer(ServerboundPackets.createPacketToggleNV());
 	}
 }

--- a/src/main/java/techreborn/config/TechRebornConfig.java
+++ b/src/main/java/techreborn/config/TechRebornConfig.java
@@ -304,8 +304,8 @@ public class TechRebornConfig {
 	@Config(config = "items", category = "power", key = "nanoSuitCapacity", comment = "Nano Suit Energy Capacity")
 	public static long nanoSuitCapacity = 1_000_000;
 
-	@Config(config = "items", category = "power", key = "nanoSuitNightVisionCost", comment = "Nano Suit Night Vision Cost")
-	public static long nanoSuitNightVisionCost = 1;
+	@Config(config = "items", category = "power", key = "suitNightVisionCost", comment = "Nano/Quantum Suit Night Vision Cost")
+	public static long suitNightVisionCost = 1;
 
 	@Config(config = "items", category = "upgrades", key = "overclocker_speed", comment = "Overclocker behavior speed multiplier")
 	public static double overclockerSpeed = 0.25;

--- a/src/main/java/techreborn/items/armor/NanoSuitItem.java
+++ b/src/main/java/techreborn/items/armor/NanoSuitItem.java
@@ -83,7 +83,7 @@ public class NanoSuitItem extends TREnergyArmourItem implements ArmorBlockEntity
 	public void tickArmor(ItemStack stack, PlayerEntity playerEntity) {
 		// Night Vision
 		if (Objects.requireNonNull(this.getSlotType()) == EquipmentSlot.HEAD) {
-			if (stack.getOrCreateNbt().getBoolean("isActive") && tryUseEnergy(stack, TechRebornConfig.nanoSuitNightVisionCost)) {
+			if (stack.getOrCreateNbt().getBoolean("isActive") && tryUseEnergy(stack, TechRebornConfig.suitNightVisionCost)) {
 				playerEntity.addStatusEffect(new StatusEffectInstance(StatusEffects.NIGHT_VISION, 220, 1, false, false));
 			} else {
 				playerEntity.removeStatusEffect(StatusEffects.NIGHT_VISION);

--- a/src/main/java/techreborn/items/armor/QuantumSuitItem.java
+++ b/src/main/java/techreborn/items/armor/QuantumSuitItem.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
+import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.attribute.EntityAttribute;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
@@ -37,10 +38,16 @@ import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ArmorMaterial;
 import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
 import reborncore.api.items.ArmorBlockEntityTicker;
 import reborncore.api.items.ArmorRemoveHandler;
 import reborncore.common.powerSystem.RcEnergyTier;
+import reborncore.common.util.ItemUtils;
 import techreborn.config.TechRebornConfig;
+
+import java.util.List;
 
 public class QuantumSuitItem extends TREnergyArmourItem implements ArmorBlockEntityTicker, ArmorRemoveHandler {
 	public QuantumSuitItem(ArmorMaterial material, Type slot) {
@@ -83,8 +90,16 @@ public class QuantumSuitItem extends TREnergyArmourItem implements ArmorBlockEnt
 	public void tickArmor(ItemStack stack, PlayerEntity playerEntity) {
 		switch (this.getSlotType()) {
 			case HEAD -> {
+				// Water Breathing
 				if (playerEntity.isSubmergedInWater() && tryUseEnergy(stack, TechRebornConfig.quantumSuitBreathingCost)) {
 					playerEntity.addStatusEffect(new StatusEffectInstance(StatusEffects.WATER_BREATHING, 5, 1));
+				}
+
+				// Night Vision
+				if (stack.getOrCreateNbt().getBoolean("isActive") && tryUseEnergy(stack, TechRebornConfig.suitNightVisionCost)) {
+					playerEntity.addStatusEffect(new StatusEffectInstance(StatusEffects.NIGHT_VISION, 220, 1, false, false));
+				} else {
+					playerEntity.removeStatusEffect(StatusEffects.NIGHT_VISION);
 				}
 			}
 			case CHEST -> {
@@ -129,6 +144,15 @@ public class QuantumSuitItem extends TREnergyArmourItem implements ArmorBlockEnt
 				playerEntity.getAbilities().flying = false;
 				playerEntity.sendAbilitiesUpdate();
 			}
+		} else if (this.getSlotType() == EquipmentSlot.HEAD) {
+			playerEntity.removeStatusEffect(StatusEffects.NIGHT_VISION);
+		}
+	}
+
+	@Override
+	public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+		if (this.getSlotType() == EquipmentSlot.HEAD) {
+			ItemUtils.buildActiveTooltip(stack, tooltip);
 		}
 	}
 }

--- a/src/main/java/techreborn/packets/ServerboundPackets.java
+++ b/src/main/java/techreborn/packets/ServerboundPackets.java
@@ -63,7 +63,7 @@ public class ServerboundPackets {
 	public static final Identifier PUMP_DEPTH = new Identifier(TechReborn.MOD_ID, "pump_depth");
 	public static final Identifier PUMP_RANGE = new Identifier(TechReborn.MOD_ID, "pump_range");
 
-	public static final Identifier NANO_SUIT_NIGHT_VISION = new Identifier(TechReborn.MOD_ID, "nano_suit_night_vision");
+	public static final Identifier SUIT_NIGHT_VISION = new Identifier(TechReborn.MOD_ID, "suit_night_vision");
 
 	public static void init() {
 		NetworkManager.registerServerBoundHandler(AESU, (server, player, handler, buf, responseSender) -> {
@@ -229,10 +229,10 @@ public class ServerboundPackets {
 			});
 		}));
 
-		NetworkManager.registerServerBoundHandler(NANO_SUIT_NIGHT_VISION, (server, player, handler, buf, responseSender) -> {
+		NetworkManager.registerServerBoundHandler(SUIT_NIGHT_VISION, (server, player, handler, buf, responseSender) -> {
 			server.execute(() -> {
 				for (ItemStack itemStack : player.getArmorItems()) {
-					if (itemStack.isOf(TRContent.NANO_HELMET)) {
+					if (itemStack.isOf(TRContent.NANO_HELMET) || itemStack.isOf(TRContent.QUANTUM_HELMET)) {
 						itemStack.getOrCreateNbt().putBoolean("isActive", !itemStack.getOrCreateNbt().getBoolean("isActive"));
 						break;
 					}
@@ -332,7 +332,7 @@ public class ServerboundPackets {
 	}
 
 	public static IdentifiedPacket createPacketToggleNV() {
-		return NetworkManager.createServerBoundPacket(NANO_SUIT_NIGHT_VISION, buf -> {
+		return NetworkManager.createServerBoundPacket(SUIT_NIGHT_VISION, buf -> {
 		});
 	}
 }

--- a/src/main/resources/assets/techreborn/lang/en_us.json
+++ b/src/main/resources/assets/techreborn/lang/en_us.json
@@ -860,7 +860,7 @@
   "_comment29": "Keybindings",
   "key.techreborn.category": "TechReborn Category",
   "key.techreborn.config": "Config",
-  "key.techreborn.nanoSuitNightVision": "Nanosuit - toggle night vision",
+  "key.techreborn.suitNightVision": "Helmet - toggle night vision",
 
   "_comment19": "JEI Integration",
   "techreborn.jei.recipe.start.cost": "Start: %s",

--- a/src/main/resources/assets/techreborn/lang/rpr.json
+++ b/src/main/resources/assets/techreborn/lang/rpr.json
@@ -823,7 +823,7 @@
   "_comment29": "Горячие клавиши",
   "key.techreborn.category": "Раздел TechReborn",
   "key.techreborn.config": "Конфиг",
-  "key.techreborn.nanoSuitNightVision": "Нанокостюм - переключение ночного видения",
+  "key.techreborn.suitNightVision": "Нанокостюм - переключение ночного видения",
   "_comment19": "Интеграция JEI",
   "techreborn.jei.recipe.start.cost": "Начало: %s",
   "techreborn.jei.recipe.running.cost": "%s/t: %s",

--- a/src/main/resources/assets/techreborn/lang/ru_ru.json
+++ b/src/main/resources/assets/techreborn/lang/ru_ru.json
@@ -823,7 +823,7 @@
   "_comment29": "Горячие клавиши",
   "key.techreborn.category": "Раздел TechReborn",
   "key.techreborn.config": "Конфиг",
-  "key.techreborn.nanoSuitNightVision": "Нанокостюм - переключение ночного видения",
+  "key.techreborn.suitNightVision": "Нанокостюм - переключение ночного видения",
   "_comment19": "Интеграция JEI",
   "techreborn.jei.recipe.start.cost": "Начало: %s",
   "techreborn.jei.recipe.running.cost": "%s/t: %s",


### PR DESCRIPTION
I found the switch from the nano helmet to the quantum helmet to be more of a sidegrade rather than a strict upgrade. I believe the quantum helmet should be a strict upgrade to the nano helmet, so I added the same night vision toggle to it.

The quantum helmet's night vision behaves the same as the nano helmet, with the same energy cost, and it uses the same keybind to toggle it.

I changed variable names involving nano suit night vision to a more generic suit night vision. I also changed the keybind text to "Helmet - toggle night vision". I don't love the text, as there are other helmets included in TR, but I thought saying something like "Nanosuit/Quantumsuit - toggle night vision" was too long.