### PR TITLE
Toggle quantum legs sprint boost

### DIFF
--- a/src/client/java/techreborn/TechRebornClient.java
+++ b/src/client/java/techreborn/TechRebornClient.java
@@ -138,6 +138,12 @@ public class TechRebornClient implements ClientModInitializer {
 			}
 		});
 
+		ClientTickEvents.END_CLIENT_TICK.register(client -> {
+			while (KeyBindings.quantumSuitSprint.wasPressed()) {
+				KeyBindings.handleQuantumSuitSprintToggle();
+			}
+		});
+
 		StackToolTipHandler.setup();
 		ClientboundPacketHandlers.init();
 

--- a/src/client/java/techreborn/client/keybindings/KeyBindings.java
+++ b/src/client/java/techreborn/client/keybindings/KeyBindings.java
@@ -39,6 +39,7 @@ public class KeyBindings {
 	public static KeyBinding config = new KeyBinding(CONFIG, GLFW.GLFW_KEY_P, CATEGORY);
 
 	public static KeyBinding suitNightVision;
+	public static KeyBinding quantumSuitSprint;
 
 	public static void registerKeys() {
 		suitNightVision = KeyBindingHelper.registerKeyBinding(
@@ -46,9 +47,19 @@ public class KeyBindings {
 				InputUtil.Type.KEYSYM,
 				GLFW.GLFW_KEY_N,
 				CATEGORY));
+
+		quantumSuitSprint = KeyBindingHelper.registerKeyBinding(
+			new KeyBinding("key.techreborn.quantumSuitSprint",
+				InputUtil.Type.KEYSYM,
+				GLFW.GLFW_KEY_B,
+				CATEGORY));
 	}
 
 	public static void handleSuitNVToggle() {
 		ClientNetworkManager.sendToServer(ServerboundPackets.createPacketToggleNV());
+	}
+
+	public static void handleQuantumSuitSprintToggle() {
+		ClientNetworkManager.sendToServer(ServerboundPackets.createPacketToggleQuantumSprint());
 	}
 }

--- a/src/main/java/techreborn/items/armor/QuantumSuitItem.java
+++ b/src/main/java/techreborn/items/armor/QuantumSuitItem.java
@@ -71,7 +71,7 @@ public class QuantumSuitItem extends TREnergyArmourItem implements ArmorBlockEnt
 
 		attributes.removeAll(EntityAttributes.GENERIC_MOVEMENT_SPEED);
 
-		if (this.getSlotType() == EquipmentSlot.LEGS && equipmentSlot == EquipmentSlot.LEGS && TechRebornConfig.quantumSuitEnableSprint) {
+		if (this.getSlotType() == EquipmentSlot.LEGS && equipmentSlot == EquipmentSlot.LEGS && stack.getOrCreateNbt().getBoolean("isActive") && TechRebornConfig.quantumSuitEnableSprint) {
 			if (getStoredEnergy(stack) > TechRebornConfig.quantumSuitSprintingCost) {
 				attributes.put(EntityAttributes.GENERIC_MOVEMENT_SPEED, new EntityAttributeModifier(MODIFIERS[equipmentSlot.getEntitySlotId()], "Movement Speed", 0.15, EntityAttributeModifier.Operation.ADDITION));
 			}
@@ -123,7 +123,7 @@ public class QuantumSuitItem extends TREnergyArmourItem implements ArmorBlockEnt
 				}
 			}
 			case LEGS -> {
-				if (playerEntity.isSprinting() && TechRebornConfig.quantumSuitEnableSprint) {
+				if (playerEntity.isSprinting() && stack.getOrCreateNbt().getBoolean("isActive") && TechRebornConfig.quantumSuitEnableSprint) {
 					tryUseEnergy(stack, TechRebornConfig.quantumSuitSprintingCost);
 				}
 			}
@@ -152,6 +152,11 @@ public class QuantumSuitItem extends TREnergyArmourItem implements ArmorBlockEnt
 	@Override
 	public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
 		if (this.getSlotType() == EquipmentSlot.HEAD) {
+			ItemUtils.buildActiveTooltip(stack, tooltip);
+		}
+
+		// Will only add Inactive/Active tooltip if sprint is enabled
+		if (this.getSlotType() == EquipmentSlot.LEGS && TechRebornConfig.quantumSuitEnableSprint) {
 			ItemUtils.buildActiveTooltip(stack, tooltip);
 		}
 	}

--- a/src/main/java/techreborn/packets/ServerboundPackets.java
+++ b/src/main/java/techreborn/packets/ServerboundPackets.java
@@ -64,6 +64,7 @@ public class ServerboundPackets {
 	public static final Identifier PUMP_RANGE = new Identifier(TechReborn.MOD_ID, "pump_range");
 
 	public static final Identifier SUIT_NIGHT_VISION = new Identifier(TechReborn.MOD_ID, "suit_night_vision");
+	public static final Identifier QUANTUM_SUIT_SPRINT = new Identifier(TechReborn.MOD_ID, "quantum_suit_sprint");
 
 	public static void init() {
 		NetworkManager.registerServerBoundHandler(AESU, (server, player, handler, buf, responseSender) -> {
@@ -239,6 +240,17 @@ public class ServerboundPackets {
 				}
 			});
 		});
+
+		NetworkManager.registerServerBoundHandler(QUANTUM_SUIT_SPRINT, (server, player, handler, buf, responseSender) -> {
+			server.execute(() -> {
+				for (ItemStack itemStack : player.getArmorItems()) {
+					if (itemStack.isOf(TRContent.QUANTUM_LEGGINGS)) {
+						itemStack.getOrCreateNbt().putBoolean("isActive", !itemStack.getOrCreateNbt().getBoolean("isActive"));
+						break;
+					}
+				}
+			});
+		});
 	}
 
 	public static IdentifiedPacket createPacketAesu(int buttonID, boolean shift, boolean ctrl, AdjustableSUBlockEntity blockEntity) {
@@ -334,5 +346,9 @@ public class ServerboundPackets {
 	public static IdentifiedPacket createPacketToggleNV() {
 		return NetworkManager.createServerBoundPacket(SUIT_NIGHT_VISION, buf -> {
 		});
+	}
+
+	public static IdentifiedPacket createPacketToggleQuantumSprint() {
+		return NetworkManager.createServerBoundPacket(QUANTUM_SUIT_SPRINT, buf -> { }); 
 	}
 }

--- a/src/main/resources/assets/techreborn/lang/en_us.json
+++ b/src/main/resources/assets/techreborn/lang/en_us.json
@@ -861,6 +861,7 @@
   "key.techreborn.category": "TechReborn Category",
   "key.techreborn.config": "Config",
   "key.techreborn.suitNightVision": "Helmet - toggle night vision",
+  "key.techreborn.quantumSuitSprint": "Quantum suit - toggle sprint speed",
 
   "_comment19": "JEI Integration",
   "techreborn.jei.recipe.start.cost": "Start: %s",


### PR DESCRIPTION
Similar to toggling night vision on the nanosuit, I want the option to toggle the movement speed boost on the quantum legs as well.

I created a new keybinding with the description "Quantum suit - toggle sprint speed". It is by default bound to b, which is not a great key, but it is unconflicted with vanilla MC's keybindings.

Everything else is basically behavior I took from the nanosuit's night vision code and ported to the quantum suit.