### PR TITLE
Use PlayerAbilityLib for quantum chestplate flight

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,16 @@ allprojects {
     apply plugin: "fabric-loom"
     apply plugin: "maven-publish"
 
+    repositories {
+        maven {
+            name "Ladysnake Mods"
+            url "https://maven.ladysnake.org/releases"
+            content {
+                includeGroup "io.github.ladysnake"
+            }
+        }
+    }
+
     loom {
         runtimeOnlyLog4j = true
         splitEnvironmentSourceSets()
@@ -50,6 +60,10 @@ allprojects {
         modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fapi_version}"
 
         include(modApi("teamreborn:energy:${project.energy_version}")) {
+            transitive = false
+        }
+
+        include(modApi("io.github.ladysnake:PlayerAbilityLib:${project.pal_version}")) {
             transitive = false
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ fapi_version=0.96.4+1.20.4
 # Dependencies
 energy_version=3.0.0
 rei_version=14.0.687
+pal_version=1.9.0


### PR DESCRIPTION
This is a very simple patch that adds PlayerAbilityLib support to quantum chestplate flight. I wrote it after experiencing interference with other forms of creative flights on large modpacks and have since been porting it to newer versions without any issues. Now, I have come up with the great idea to submit a PR.

This patch is pretty straightforward. Possibly the only nontrivial part of logic is that this only applies the energy cost of flight if the chestplate is **the** source of flight, due to `isActivelyGranting`. For example, in creative mode or using a sustainable flight provider (think some angel ring), this should not discharge while flying.

This probably addresses #3186.