### PR TITLE
Fix Elevator. Closes #3305

### DIFF
--- a/src/main/java/techreborn/packets/ServerboundPackets.java
+++ b/src/main/java/techreborn/packets/ServerboundPackets.java
@@ -126,7 +126,7 @@ public class ServerboundPackets {
 		});
 
 		ServerPlayNetworking.registerGlobalReceiver(JumpPayload.ID, (payload, context) -> {
-			MachineBaseBlockEntity legacyMachineBase = (MachineBaseBlockEntity) context.player().getWorld().getBlockEntity(payload.pos());
+			MachineBaseBlockEntity legacyMachineBase = (MachineBaseBlockEntity) context.player().getWorld().getBlockEntity(payload.pos().down());
 			if (legacyMachineBase instanceof ElevatorBlockEntity) {
 				((ElevatorBlockEntity) legacyMachineBase).teleportUp(context.player());
 			}


### PR DESCRIPTION
Fix broken elevators after https://github.com/TechReborn/TechReborn/commit/19c0df13d2e74057b5ec04b97e890cc913a356c6
pos missing down function call
```java
NetworkManager.registerServerBoundHandler(JUMP, (server, player, handler, buf, responseSender) -> {
	BlockPos pos = buf.readBlockPos();

	server.execute(() -> {
		BlockEntity blockEntity = player.getWorld().getBlockEntity(pos.down());
		if (blockEntity instanceof ElevatorBlockEntity elevator) {
			elevator.teleportUp(player);
		}
	});
});
```
```diff
NetworkManager.registerServerBoundHandler(JumpPayload.ID, (payload, context) -> {
-	MachineBaseBlockEntity legacyMachineBase = (MachineBaseBlockEntity) context.player().getWorld().getBlockEntity(payload.pos());
+	MachineBaseBlockEntity legacyMachineBase = (MachineBaseBlockEntity) context.player().getWorld().getBlockEntity(payload.pos().down());
	if (legacyMachineBase instanceof ElevatorBlockEntity) {
		((ElevatorBlockEntity) legacyMachineBase).teleportUp(context.player());
	}
});
```