### PR TITLE
Fix REI fluid first render

### DIFF
--- a/src/client/java/techreborn/client/compat/rei/ReiPlugin.java
+++ b/src/client/java/techreborn/client/compat/rei/ReiPlugin.java
@@ -308,7 +308,7 @@ public class ReiPlugin implements REIClientPlugin {
 
 	public static Widget createFluidDisplay(Rectangle bounds, EntryStack<FluidStack> fluid, EntryAnimation animation) {
 		EntryStack<FluidStack> copy = fluid.copy();
-		fluid.withRenderer(new FluidStackRenderer(animation, copy.getRenderer()));
+		copy.withRenderer(new FluidStackRenderer(animation, copy.getRenderer()));
 		return Widgets.createSlot(bounds).entry(copy);
 	}
 


### PR DESCRIPTION
Entering the game, there is an error when loading for the first time, and the fluid appears black.

![black](https://github.com/user-attachments/assets/05a156b2-a3d1-4a63-b36c-99eb58942adf)
