### PR TITLE
Fix Storage Buffer item lose. Closed #3119(Jun 25)

### DIFF
--- a/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
@@ -192,8 +192,8 @@ public class StorageUnitBaseBlockEntity extends MachineBaseBlockEntity implement
 			return inputStack;
 		}
 
-		if (getDisplayedStack().isEmpty()) {
-			// Check if storage is empty, including the output slot and locked stack
+		if (storeItemStack.isEmpty() && inventory.getStack(OUTPUT_SLOT).isEmpty()) {
+			// Check if storage is empty, including the output slot
 			storeItemStack = inputStack.copy();
 
 			if (inputStack.getCount() <= maxCapacity) {

--- a/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
@@ -192,53 +192,43 @@ public class StorageUnitBaseBlockEntity extends MachineBaseBlockEntity implement
 			return inputStack;
 		}
 
-		if (storeItemStack.isEmpty() && inventory.getStack(OUTPUT_SLOT).isEmpty() && (!isLocked() || !ItemUtils.canExtractAnyFromShulker(inputStack, lockedItemStack))) {
-			// Check if storage is empty, including the output slot
-			storeItemStack = inputStack.copy();
-
-			if (inputStack.getCount() <= maxCapacity) {
-				inputStack = ItemStack.EMPTY;
-			} else {
-				// Stack is higher than capacity
-				storeItemStack.setCount(maxCapacity);
-				inputStack.decrement(maxCapacity);
+		// Amount of items that can be added before reaching capacity
+		int reminder = maxCapacity - getCurrentCapacity();
+		DefaultedList<ItemStack> optionalShulkerStack = ItemUtils.getBlockEntityStacks(inputStack);
+		if (isLocked() && ItemUtils.canExtractFromCachedShulker(optionalShulkerStack, lockedItemStack) > 0 ) {
+			Pair<Integer, ItemStack> pair = ItemUtils.extractFromShulker(inputStack, optionalShulkerStack, lockedItemStack, reminder);
+			if (pair.getLeft() != 0) {
+				int amount = pair.getLeft();
+				if (storeItemStack.isEmpty()) {
+					storeItemStack = lockedItemStack.copy();
+					amount = amount -1;
+				}
+				addStoredItemCount(amount);
+				inputStack = pair.getRight().copy();
+				inventory.setHashChanged();
 			}
+			return inputStack;
+		}
+		if (inputStack.getCount() <= reminder) {
+			// Add full stack
+			if (storeItemStack == ItemStack.EMPTY){
+				// copy input stack into stored if everything is in OUTPUT_SLOT
+				storeItemStack = inputStack.copy();
+			}
+			else {
+				addStoredItemCount(inputStack.getCount());
+			}
+
+			inputStack = ItemStack.EMPTY;
 		} else {
-			// Not empty but same type
-
-			// Amount of items that can be added before reaching capacity
-			int reminder = maxCapacity - getCurrentCapacity();
-			DefaultedList<ItemStack> optionalShulkerStack = ItemUtils.getBlockEntityStacks(inputStack);
-			if (isLocked() && ItemUtils.canExtractFromCachedShulker(optionalShulkerStack, lockedItemStack) > 0 ) {
-				Pair<Integer, ItemStack> pair = ItemUtils.extractFromShulker(inputStack, optionalShulkerStack, lockedItemStack, reminder);
-				if (pair.getLeft() != 0) {
-					int amount = pair.getLeft();
-					if (storeItemStack.isEmpty()) {
-						storeItemStack = lockedItemStack.copy();
-						amount = amount -1;
-					}
-					addStoredItemCount(amount);
-					inputStack = pair.getRight().copy();
-					inventory.setHashChanged();
-				}
-				return inputStack;
-			}
-			if (inputStack.getCount() <= reminder) {
-				// Add full stack
-				if (storeItemStack == ItemStack.EMPTY){
-					// copy input stack into stored if everything is in OUTPUT_SLOT
-					storeItemStack = inputStack.copy();
-				}
-				else {
-					addStoredItemCount(inputStack.getCount());
-				}
-
-				inputStack = ItemStack.EMPTY;
+			// Add only what is needed to reach max capacity
+			if (storeItemStack == ItemStack.EMPTY) {
+				storeItemStack = inputStack.copy();
+				storeItemStack.setCount(reminder);
 			} else {
-				// Add only what is needed to reach max capacity
 				addStoredItemCount(reminder);
-				inputStack.decrement(reminder);
 			}
+			inputStack.decrement(reminder);
 		}
 
 		inventory.setHashChanged();

--- a/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java
@@ -192,7 +192,7 @@ public class StorageUnitBaseBlockEntity extends MachineBaseBlockEntity implement
 			return inputStack;
 		}
 
-		if (storeItemStack.isEmpty() && inventory.getStack(OUTPUT_SLOT).isEmpty()) {
+		if (storeItemStack.isEmpty() && inventory.getStack(OUTPUT_SLOT).isEmpty() && (!isLocked() || !ItemUtils.canExtractAnyFromShulker(inputStack, lockedItemStack))) {
 			// Check if storage is empty, including the output slot
 			storeItemStack = inputStack.copy();
 


### PR DESCRIPTION
Fix broken buffer item input after https://github.com/TechReborn/TechReborn/commit/c8e04537a04b09d0b279c7d4f6fa9d82d1761c14

## Reproduce bug:
- StorageUnit is **Locked**
- storeItemStack is **EMPTY**
- one **input** count > maximum remaining **space**

## Question:
**addStoredItemCount** increment **minecraft:air** causes items to be lost

## Test:
#### Storage Buffer: (error)
maxCapacity is 1
storeItemStack empty is 0\~1  (1 pass isFull check)
one input 2\~64 > 1 - 0 **Lost items**
#### Crude Storage Unit: (pass)
maxCapacity is 2048
storeItemStack empty is 0\~64
one input 1\~64 > 2048 - 64 **impossible**

## Code
src/main/java/techreborn/blockentity/storage/item/StorageUnitBaseBlockEntity.java https://github.com/TechReborn/TechReborn/commit/c8e04537a04b09d0b279c7d4f6fa9d82d1761c14
```diff
public ItemStack processInput(ItemStack inputStack) {

-	boolean isSameStack = canAcceptStack(inputStack);
	if (!isValid(INPUT_SLOT, inputStack)){
		return inputStack;
	}

-	if (storeItemStack == ItemStack.EMPTY && (isSameStack || (getCurrentCapacity() == 0 && !isLocked()))) {
+	if (getDisplayedStack().isEmpty()) {
		...
	} else {    // lockedItemStack count is always 1
		int reminder = maxCapacity - getCurrentCapacity();

		if (inputStack.getCount() <= reminder) {
			...
		} else {
			addStoredItemCount(reminder);    // storeItemStack is EMPTY
			inputStack.decrement(reminder);
		}
	}
```
```java
public boolean canAcceptStack(ItemStack inputStack) {
	if (inputStack == ItemStack.EMPTY){
		return false;
	}
	if (isLocked()) {
		return ItemUtils.isItemEqual(lockedItemStack, inputStack, true, true);
	}

	if (isEmpty()){
		return true;
	}

	return ItemUtils.isItemEqual(getStoredStack(), inputStack, true, true);
}

public ItemStack getStoredStack() {
	return storeItemStack.isEmpty() ? inventory.getStack(OUTPUT_SLOT) : storeItemStack;
}

// Returns the ItemStack to be displayed to the player via UI / model
public ItemStack getDisplayedStack() {
	if (!isLocked()) {
		return getStoredStack();
	} else {
		// Render the locked stack even if the unit is empty
		return lockedItemStack;
	}
}
```

## Fix: remove isLocked check
1. `getDisplayedStack().isEmpty()`
2. `isLocked() ? false : (storeItemStack.isEmpty() ? inventory.getStack(OUTPUT_SLOT).isEmpty() : false)`
3. `storeItemStack.isEmpty() ? inventory.getStack(OUTPUT_SLOT).isEmpty() : false`
4. `storeItemStack.isEmpty() && inventory.getStack(OUTPUT_SLOT).isEmpty()`

**isValid function has checked isLocked**
```java
public boolean isValid(int slot, ItemStack inputStack) {
	...
	if (isLocked()) {
		//allow shulker bundle extraction when locked
		if (ItemUtils.canExtractAnyFromShulker(inputStack, lockedItemStack)) {
			return true;
		}
		return ItemUtils.isItemEqual(lockedItemStack, inputStack, true, true);
	}
	...
}
```
```diff
public ItemStack processInput(ItemStack inputStack) {
	if (!isValid(INPUT_SLOT, inputStack)){
		return inputStack;
	}

-	if (getDisplayedStack().isEmpty()) {
+	if (storeItemStack.isEmpty() && inventory.getStack(OUTPUT_SLOT).isEmpty()) {
		// Check if storage is empty, including the output slot
		storeItemStack = inputStack.copy();

		if (inputStack.getCount() <= maxCapacity) {
			inputStack = ItemStack.EMPTY;
		} else {
			// Stack is higher than capacity
			storeItemStack.setCount(maxCapacity);
			inputStack.decrement(maxCapacity);
		}
	} else {
```