### PR TITLE
Fix changing nbt after extracting shulkers

### DIFF
--- a/RebornCore/src/main/java/reborncore/common/util/ItemUtils.java
+++ b/RebornCore/src/main/java/reborncore/common/util/ItemUtils.java
@@ -129,6 +129,7 @@ public class ItemUtils {
 			newStack.set(DataComponentTypes.CONTAINER, ContainerComponent.DEFAULT);
 			return new Pair<>(extracted, newStack);
 		}
+		newStack.set(DataComponentTypes.CONTAINER, ContainerComponent.fromStacks(entityStack));
 		return new Pair<>(extracted, newStack);
 	}
 


### PR DESCRIPTION
## Unlimited copy of items
![screenshots](https://github.com/user-attachments/assets/16357572-5d90-447c-affd-0424cdec1985)
## Code
Fix broken extract from Shulker after https://github.com/TechReborn/TechReborn/commit/45bbe2c3dae2c52787f41894005809652644c7fe

RebornCore/src/main/java/reborncore/common/util/ItemUtils.java https://github.com/TechReborn/TechReborn/commit/45bbe2c3dae2c52787f41894005809652644c7fe
```diff
public static Pair<Integer, ItemStack> extractFromShulker(ItemStack shulkerStack, DefaultedList<ItemStack> entityStack, ItemStack targetStack, int capacity) {
	ItemStack newStack = shulkerStack.copy();
	if (entityStack == null) {
			return new Pair<>(0, shulkerStack);
	}
	int extracted = extractableFromCachedShulker(entityStack, targetStack, capacity);
	if (extracted == 0) {
		return new Pair<>(0, shulkerStack);
	}
-	NbtCompound blockEntityTag = newStack.getSubNbt("BlockEntityTag");
-	if (blockEntityTag == null) throw new IllegalStateException("BlockEntityTag is removed during operation!");
	if (isStackListEmpty(entityStack)) {
		newStack.set(DataComponentTypes.CONTAINER, ContainerComponent.DEFAULT);
		return new Pair<>(extracted, newStack);
	}
-	Inventories.writeNbt(blockEntityTag, entityStack);
	return new Pair<>(extracted, newStack);
}
```
Fix: save changes to entityStack to newStack
```diff
public static Pair<Integer, ItemStack> extractFromShulker(ItemStack shulkerStack, DefaultedList<ItemStack> entityStack, ItemStack targetStack, int capacity) {
	...
	if (isStackListEmpty(entityStack)) {
		newStack.set(DataComponentTypes.CONTAINER, ContainerComponent.DEFAULT);
		return new Pair<>(extracted, newStack);
	}
+	newStack.set(DataComponentTypes.CONTAINER, ContainerComponent.fromStacks(entityStack));
	return new Pair<>(extracted, newStack);
}
```