### PR TITLE
Fix spectator armor depleted. Closes #3313

### DIFF
--- a/RebornCore/src/main/java/reborncore/mixin/common/MixinPlayerEntity.java
+++ b/RebornCore/src/main/java/reborncore/mixin/common/MixinPlayerEntity.java
@@ -48,6 +48,7 @@ public abstract class MixinPlayerEntity extends LivingEntity {
 
 	@Inject(method = "tick", at = @At("HEAD"))
 	public void tick(CallbackInfo info) {
+		if (((PlayerEntity) (Object) this).isSpectator()) return;
 		for (ItemStack stack : getArmorItems()) {
 			if (!stack.isEmpty() && stack.getItem() instanceof ArmorBlockEntityTicker) {
 				((ArmorBlockEntityTicker) stack.getItem()).tickArmor(stack, (PlayerEntity) (Object) this);


### PR DESCRIPTION
Skipping the armor's special effects in spectator mode should have little impact.