### PR TITLE
Fix Key binding P key invalid. Closes #3278

### DIFF
--- a/src/client/java/techreborn/client/keybindings/KeyBindings.java
+++ b/src/client/java/techreborn/client/keybindings/KeyBindings.java
@@ -35,9 +35,6 @@ import techreborn.packets.serverbound.SuitNightVisionPayload;
 public class KeyBindings {
 	// Actual keybindings are in TechRebornClient
 	public static final String CATEGORY = "key.techreborn.category";
-	public static final String CONFIG = "key.techreborn.config";
-
-	public static KeyBinding config = new KeyBinding(CONFIG, GLFW.GLFW_KEY_P, CATEGORY);
 
 	public static KeyBinding suitNightVision;
 	public static KeyBinding quantumSuitSprint;


### PR DESCRIPTION
Debugging decompiled class files, new KeyBinding() will be added to three HashMap

```java
// net.minecraft.client.option.KeyBinding
public KeyBinding(String translationKey, InputUtil.Type type, int code, String category) {
    ...
    KEYS_BY_ID.put(translationKey, this);
    KEY_TO_BINDINGS.put(this.boundKey, this);
    KEY_CATEGORIES.add(category);
}
```
Unfortunately, TechReborn registered the P key, but didn't use it
https://github.com/TechReborn/TechReborn/blob/98882e06bd55da05a8a1676547cc5566b4d8c647/src/client/java/techreborn/client/keybindings/KeyBindings.java#L35-L40

key binding process
1. new KeyBinding() in the code add to map
2. new GameOptions() call KeyBinding.updateKeysByCode()
3. clear KEY_TO_BINDINGS then use KEYS_BY_ID order
4. KEYS_BY_ID uses translationKey string hash order
![list](https://github.com/user-attachments/assets/439761b0-4b9f-4c0e-b0c8-53236a70c64a)
Therefore, if the hash value of key happens to be in front of "key.techreborn.config", the key will be overwritten and invalid.
```java
    public static void updateKeysByCode() {
        KEY_TO_BINDINGS.clear();
        Iterator var0 = KEYS_BY_ID.values().iterator();

        while(var0.hasNext()) {
            KeyBinding keyBinding = (KeyBinding)var0.next();
            KEY_TO_BINDINGS.put(keyBinding.boundKey, keyBinding);
        }

    }
```