### PR TITLE
Fix load laggy chunks. Closes #3270

### DIFF
--- a/RebornCore/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
+++ b/RebornCore/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
@@ -301,7 +301,7 @@ public class MachineBaseBlockEntity extends BlockEntity implements BlockEntityTi
 	public void writeNbt(NbtCompound tagCompound, RegistryWrapper.WrapperLookup registryLookup) {
 		super.writeNbt(tagCompound, registryLookup);
 		if (getOptionalInventory().isPresent()) {
-			getOptionalInventory().get().write(tagCompound);
+			getOptionalInventory().get().write(tagCompound, registryLookup);
 		}
 		if (getOptionalCrafter().isPresent()) {
 			getOptionalCrafter().get().write(tagCompound);
@@ -312,7 +312,7 @@ public class MachineBaseBlockEntity extends BlockEntity implements BlockEntityTi
 		if (fluidConfiguration != null) {
 			tagCompound.put("fluidConfig", fluidConfiguration.write());
 		}
-		upgradeInventory.write(tagCompound, "Upgrades");
+		upgradeInventory.write(tagCompound, "Upgrades", registryLookup);
 		tagCompound.put("redstoneConfig", RedstoneConfiguration.CODEC.codec()
 			.encodeStart(NbtOps.INSTANCE, redstoneConfiguration).result().get());
 	}

--- a/RebornCore/src/main/java/reborncore/common/util/RebornInventory.java
+++ b/RebornCore/src/main/java/reborncore/common/util/RebornInventory.java
@@ -107,12 +107,12 @@ public class RebornInventory<T extends MachineBaseBlockEntity> extends Inventory
 		hasChanged = true;
 	}
 
-	public void write(NbtCompound data) {
-		write(data, "Items");
+	public void write(NbtCompound data, RegistryWrapper.WrapperLookup registryLookup) {
+		write(data, "Items", registryLookup);
 	}
 
-	public void write(NbtCompound data, String tag) {
-		data.put(tag, serializeNBT(Objects.requireNonNull(blockEntity.getWorld()).getRegistryManager()));
+	public void write(NbtCompound data, String tag, RegistryWrapper.WrapperLookup registryLookup) {
+		data.put(tag, serializeNBT(registryLookup));
 	}
 
 

--- a/RebornCore/src/main/java/reborncore/common/util/RebornInventory.java
+++ b/RebornCore/src/main/java/reborncore/common/util/RebornInventory.java
@@ -33,7 +33,6 @@ import reborncore.api.items.InventoryBase;
 import reborncore.common.blockentity.MachineBaseBlockEntity;
 import reborncore.common.blockentity.SlotConfiguration;
 
-import java.util.Objects;
 
 public class RebornInventory<T extends MachineBaseBlockEntity> extends InventoryBase {
 

--- a/src/main/java/techreborn/blockentity/machine/tier3/ChunkLoaderBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/tier3/ChunkLoaderBlockEntity.java
@@ -131,7 +131,7 @@ public class ChunkLoaderBlockEntity extends MachineBaseBlockEntity implements IT
 		if (ownerUdid != null && !ownerUdid.isEmpty()){
 			tagCompound.putString("ownerUdid", ownerUdid);
 		}
-		inventory.write(tagCompound);
+		inventory.write(tagCompound, registryLookup);
 	}
 
 	@Override


### PR DESCRIPTION
support LoadMyChunks mod
![{9E5616D1-4EB6-492D-9BAA-B3164AD12B1F}](https://github.com/user-attachments/assets/eb300633-e023-47b7-8668-ffd9bcd59375)
## Reproduce bug:
1. blockEntity.getWorld() is null when new RebornInventory() is called for the first time.
2. When the chunk loading rules are adjusted, such as using LoadMyChunks, the unloaded chunks will not be ticked.
> Load My Chunks
> Block Entity ticking is now executed chunk-wise rather than dimension wise. Chunks time their tick duration only if necessary.
>
> Chunks are forceloaded only if they contain at least one chunk loader. If the chunk tick duration exceeds the server side maximum, then the chunk will cease being forceloaded and enter a dormant state for some time.
3. When saving a chunk when the block entity **world** property is not loaded, calling `Objects.requireNonNull(blockEntity.getWorld()).getRegistryManager()` will trigger a null pointer exception.

## Fix
Looking at the relevant code, we found that the read function corresponding to the write function passes the registryLookup parameter.
https://github.com/TechReborn/TechReborn/blob/98882e06bd55da05a8a1676547cc5566b4d8c647/RebornCore/src/main/java/reborncore/common/util/RebornInventory.java#L104-L116
So passing the parent's RegistryWrapper.WrapperLookup parameter to fix