### PR TITLE
Fix slot config canWorldBlockInsert call

### DIFF
--- a/RebornCore/src/client/java/reborncore/client/gui/config/SlotConfigGui.java
+++ b/RebornCore/src/client/java/reborncore/client/gui/config/SlotConfigGui.java
@@ -41,6 +41,7 @@ import reborncore.client.gui.config.elements.ConfigSlotElement;
 import reborncore.client.gui.config.elements.SlotType;
 import reborncore.common.network.serverbound.SlotConfigSavePayload;
 import reborncore.common.screen.BuiltScreenHandler;
+import reborncore.common.screen.slot.BaseSlot;
 import reborncore.common.util.Color;
 
 import java.util.List;
@@ -84,7 +85,7 @@ public class SlotConfigGui extends GuiTab {
 
 			ConfigSlotElement slotElement = new ConfigSlotElement(
 				guiBase.getMachine().getOptionalInventory().get(),
-				slot.getIndex(),
+				(BaseSlot) slot,
 				SlotType.NORMAL,
 				slot.x - guiBase.getGuiLeft() + 50,
 				slot.y - guiBase.getGuiTop() - 25,

--- a/RebornCore/src/client/java/reborncore/client/gui/config/elements/AbstractConfigPopupElement.java
+++ b/RebornCore/src/client/java/reborncore/client/gui/config/elements/AbstractConfigPopupElement.java
@@ -42,10 +42,11 @@ import reborncore.common.blockentity.MachineBaseBlockEntity;
 import reborncore.common.util.MachineFacing;
 
 public abstract class AbstractConfigPopupElement extends ElementBase {
-	public boolean filter = false;
+	private final int height;
 
-	public AbstractConfigPopupElement(int x, int y, SpriteIdentifier sprite) {
+	public AbstractConfigPopupElement(int x, int y, int height, SpriteIdentifier sprite) {
 		super(x, y, sprite);
+		this.height = height;
 	}
 
 	@Override
@@ -56,7 +57,7 @@ public abstract class AbstractConfigPopupElement extends ElementBase {
 			adjustX(gui, getX() - 8),
 			adjustY(gui, getY() - 7),
 			84,
-			105 + (filter ? 15 : 0)
+			height
 		);
 		drawContext.getMatrices().pop();
 

--- a/RebornCore/src/client/java/reborncore/client/gui/config/elements/ConfigFluidElement.java
+++ b/RebornCore/src/client/java/reborncore/client/gui/config/elements/ConfigFluidElement.java
@@ -38,7 +38,7 @@ public class ConfigFluidElement extends ParentElement {
 
 		FluidConfigPopupElement popupElement;
 
-		elements.add(popupElement = new FluidConfigPopupElement(x - 22, y - 22, this));
+		elements.add(popupElement = new FluidConfigPopupElement(x - 22, y - 22, getHeight(), this));
 		elements.add(new ButtonElement(x + 37, y - 25, GuiSprites.EXIT_BUTTON, gui::closeSelectedTab));
 
 		elements.add(new CheckBoxElement(Text.translatable("reborncore.gui.fluidconfig.pullin"), x - 26, y + 42,

--- a/RebornCore/src/client/java/reborncore/client/gui/config/elements/FluidConfigPopupElement.java
+++ b/RebornCore/src/client/java/reborncore/client/gui/config/elements/FluidConfigPopupElement.java
@@ -38,8 +38,8 @@ import reborncore.common.network.serverbound.FluidIoSavePayload;
 public class FluidConfigPopupElement extends AbstractConfigPopupElement {
 	ConfigFluidElement fluidElement;
 
-	public FluidConfigPopupElement(int x, int y, ConfigFluidElement fluidElement) {
-		super(x, y, GuiSprites.SLOT_CONFIG_POPUP);
+	public FluidConfigPopupElement(int x, int y, int height, ConfigFluidElement fluidElement) {
+		super(x, y, height, GuiSprites.SLOT_CONFIG_POPUP);
 		this.fluidElement = fluidElement;
 	}
 

--- a/RebornCore/src/client/java/reborncore/client/gui/config/elements/SlotConfigPopupElement.java
+++ b/RebornCore/src/client/java/reborncore/client/gui/config/elements/SlotConfigPopupElement.java
@@ -39,8 +39,8 @@ public class SlotConfigPopupElement extends AbstractConfigPopupElement {
 	private final int id;
 	private final boolean allowInput;
 
-	public SlotConfigPopupElement(int slotId, int x, int y, boolean allowInput) {
-		super(x, y, GuiSprites.SLOT_CONFIG_POPUP);
+	public SlotConfigPopupElement(int slotId, int x, int y, int height, boolean allowInput) {
+		super(x, y, height, GuiSprites.SLOT_CONFIG_POPUP);
 		this.id = slotId;
 		this.allowInput = allowInput;
 	}


### PR DESCRIPTION
![screenshots](https://github.com/user-attachments/assets/e18891a4-fa75-4ac7-ae8b-ff4f7e93259c)
```java
boolean inputEnabled = gui.builtScreenHandler.slots.stream()
		.filter(Objects::nonNull)
		.filter(slot -> slot.inventory == inventory)    // inventory is blockEntity always false
		.filter(slot -> slot instanceof BaseSlot)
		.map(slot -> (BaseSlot) slot)
		.filter(baseSlot -> baseSlot.getIndex() == slotId)
		.allMatch(BaseSlot::canWorldBlockInsert);
```
## Fix
```java
boolean inputEnabled = slot.canWorldBlockInsert();
```
Use the slot (BaseSlot) passed by the parent,
And calculate the height dynamically.
![fix](https://github.com/user-attachments/assets/4516f740-a51f-4584-b23f-78b191dc88c0)