### PR TITLE
 fix `ServerPlayerEntity` accessor breaking with alternate runtime mappings  

### DIFF
--- a/RebornCore/src/main/java/reborncore/common/screen/ServerPlayerEntityScreenHandlerHelper.java
+++ b/RebornCore/src/main/java/reborncore/common/screen/ServerPlayerEntityScreenHandlerHelper.java
@@ -24,6 +24,7 @@
 
 package reborncore.common.screen;
 
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.screen.ScreenHandlerListener;
 import net.minecraft.server.network.ServerPlayerEntity;
 
@@ -33,8 +34,8 @@ import java.util.Optional;
 
 // Helper to access the ServerPlayerEntity instance from a ScreenHandlerListener
 public class ServerPlayerEntityScreenHandlerHelper {
-	private static final String CLASS_NAME = ServerPlayerEntity.class.getName() + "$2";
-	private static final String FIELD_NAME = "field_29183";
+	private static final String CLASS_NAME = FabricLoader.getInstance().getMappingResolver().mapClassName("intermediary", "net.minecraft.class_3222$2");
+	private static final String FIELD_NAME = FabricLoader.getInstance().getMappingResolver().mapFieldName("intermediary", "net.minecraft.class_3222$2", "field_29183", "Lnet/minecraft/class_3222;");
 
 	private static final Class<?> CLAZZ;
 	private static final VarHandle VAR_HANDLE;

--- a/RebornCore/src/main/java/reborncore/common/screen/ServerPlayerEntityScreenHandlerHelper.java
+++ b/RebornCore/src/main/java/reborncore/common/screen/ServerPlayerEntityScreenHandlerHelper.java
@@ -34,8 +34,14 @@ import java.util.Optional;
 
 // Helper to access the ServerPlayerEntity instance from a ScreenHandlerListener
 public class ServerPlayerEntityScreenHandlerHelper {
-	private static final String CLASS_NAME = FabricLoader.getInstance().getMappingResolver().mapClassName("intermediary", "net.minecraft.class_3222$2");
-	private static final String FIELD_NAME = FabricLoader.getInstance().getMappingResolver().mapFieldName("intermediary", "net.minecraft.class_3222$2", "field_29183", "Lnet/minecraft/class_3222;");
+	private static final String INTERMEDIARY_NAMESPACE = "intermediary";
+	private static final String SERVER_PLAYER_ENTITY_INTERMEDIARY_NAME = "net.minecraft.class_3222";
+	private static final String INTERMEDIARY_FIELD_NAME = "field_29183";
+
+	private static final String INTERMEDIARY_ANON_CLASS_NAME = SERVER_PLAYER_ENTITY_INTERMEDIARY_NAME + "$2";
+	private static final String FIELD_DESC = "L" + SERVER_PLAYER_ENTITY_INTERMEDIARY_NAME.replace('.', '/') + ";";
+	private static final String CLASS_NAME = FabricLoader.getInstance().getMappingResolver().mapClassName(INTERMEDIARY_NAMESPACE, INTERMEDIARY_ANON_CLASS_NAME);
+	private static final String FIELD_NAME = FabricLoader.getInstance().getMappingResolver().mapFieldName(INTERMEDIARY_NAMESPACE, INTERMEDIARY_ANON_CLASS_NAME, INTERMEDIARY_FIELD_NAME, FIELD_DESC);
 
 	private static final Class<?> CLAZZ;
 	private static final VarHandle VAR_HANDLE;


### PR DESCRIPTION
since https://github.com/TechReborn/TechReborn/commit/193be50df8dfa5d6294c3b1a93dbe5cad1895a36, TR has been incompatible with development workspaces using alternate runtime mappings (such as a Quilt dev workspace using [hashed](https://github.com/QuiltMC/mappings-hasher)), because of raw intermediary names being used without applying Fabric Loader's mapping resolver API to translate. this PR implements the proper usage of the floader API to fix a crash whenever a TR screen was opened!

note that that issue has been present since that commit (tech reborn `5.4.0`), so i'd really appreciate it if the fix could be backported to versions on `1.20` as well! the patch will apply to any version without conflict, so it shouldn't take too long :)