### PR TITLE
Fix slot configuration colors

### DIFF
--- a/RebornCore/src/main/resources/assets/reborncore/theme.json
+++ b/RebornCore/src/main/resources/assets/reborncore/theme.json
@@ -3,6 +3,6 @@
 	"subtitleColor": "#AAAAAA",
 	"warningTextColor": "#FF0000",
 	"ioInputColor": "#800000FF",
-	"ioOutputColor": "#8000FF00",
-	"ioBothColor": "#80001AFF"
+	"ioOutputColor": "#80FF4500",
+	"ioBothColor": "#8034FF1E"
 }

--- a/RebornCore/src/main/resources/resourcepacks/reborncore_darkmode/assets/reborncore/theme.json
+++ b/RebornCore/src/main/resources/resourcepacks/reborncore_darkmode/assets/reborncore/theme.json
@@ -3,6 +3,6 @@
 	"subtitleColor": "#D1D1D1",
 	"warningTextColor": "#FF0000",
 	"ioInputColor": "#800000FF",
-	"ioOutputColor": "#8000FF00",
-	"ioBothColor": "#80001AFF"
+	"ioOutputColor": "#80FF4500",
+	"ioBothColor": "#8034FF1E"
 }


### PR DESCRIPTION
> Orange side means output.
> Blue side means input.
> Green side means both.

## Use old version colors:
https://github.com/TechReborn/TechReborn/blob/7528742fc0ba8e6ed56320d36656c694faa311c0/RebornCore/src/client/java/reborncore/client/gui/config/elements/FluidConfigPopupElement.java#L81-L86

## Fix
![color](https://github.com/user-attachments/assets/187fd446-8eba-44c7-99b2-4cc618a88790)
Maybe #3301 can be closed