### PR TITLE
Port/1.21.4 Use ItemModel to implement dynamic fluids

### DIFF
--- a/RebornCore/src/client/java/reborncore/client/RenderUtil.java
+++ b/RebornCore/src/client/java/reborncore/client/RenderUtil.java
@@ -26,6 +26,7 @@ package reborncore.client;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.util.Identifier;
 
 /**
@@ -33,6 +34,6 @@ import net.minecraft.util.Identifier;
  */
 public class RenderUtil {
 	public static Sprite getSprite(Identifier identifier) {
-		return MinecraftClient.getInstance().getGuiAtlasManager().getSprite(identifier);
+		return MinecraftClient.getInstance().getSpriteAtlas(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE).apply(identifier);
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,10 +6,10 @@ mod_version=5.11.13
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop/
-minecraft_version=1.21.4-rc3
-yarn_version=1.21.4-rc3+build.3
+minecraft_version=1.21.4
+yarn_version=1.21.4+build.1
 loader_version=0.16.9
-fapi_version=0.110.3+1.21.4
+fapi_version=0.110.5+1.21.4
 
 # Dependencies
 energy_version=4.1.0

--- a/src/client/java/techreborn/TechRebornClient.java
+++ b/src/client/java/techreborn/TechRebornClient.java
@@ -27,11 +27,10 @@ package techreborn;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactories;
-import net.minecraft.client.render.model.*;
+import net.minecraft.client.render.item.model.ItemModelTypes;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
@@ -49,6 +48,7 @@ import techreborn.client.ClientboundPacketHandlers;
 import techreborn.client.events.ClientJumpHandler;
 import techreborn.client.events.StackToolTipHandler;
 import techreborn.client.keybindings.KeyBindings;
+import techreborn.client.render.*;
 import techreborn.client.render.entitys.CableCoverRenderer;
 import techreborn.client.render.entitys.NukeRenderer;
 import techreborn.client.render.entitys.StorageUnitRenderer;
@@ -70,50 +70,8 @@ public class TechRebornClient implements ClientModInitializer {
 
 	@Override
 	public void onInitializeClient() {
-		ModelLoadingPlugin.register((pluginContext) -> {
-			/*
-			pluginContext.addModels(
-				DynamicCellBakedModel.CELL_BASE,
-				DynamicCellBakedModel.CELL_BACKGROUND,
-				DynamicCellBakedModel.CELL_FLUID,
-				DynamicCellBakedModel.CELL_GLASS,
-				DynamicBucketBakedModel.BUCKET_BASE,
-				DynamicBucketBakedModel.BUCKET_FLUID,
-				DynamicBucketBakedModel.BUCKET_BACKGROUND
-			);
-			*/
-
-			/*
-			pluginContext.resolveModel().register((context) -> {
-				final Identifier id = context.id();
-
-				if (!id.getNamespace().equals(TechReborn.MOD_ID) || !id.getPath().startsWith("item/")) {
-					return null;
-				}
-
-				String path = id.getPath().replace("item/", "");
-
-				if (path.equals("cell")) {
-					if (!RendererAccess.INSTANCE.hasRenderer()) {
-						return JsonUnbakedModel.deserialize("{\"parent\":\"minecraft:item/generated\",\"textures\":{\"layer0\":\"techreborn:item/cell_background\"}}");
-					}
-
-					return new UnbakedDynamicModel(DynamicCellBakedModel::new);
-				}
-
-				Fluid fluid = Registries.FLUID.get(Identifier.of(TechReborn.MOD_ID, path.split("_bucket")[0]));
-				if (path.endsWith("_bucket") && fluid != Fluids.EMPTY) {
-					if (!RendererAccess.INSTANCE.hasRenderer()) {
-						return JsonUnbakedModel.deserialize("{\"parent\":\"minecraft:item/generated\",\"textures\":{\"layer0\":\"minecraft:item/bucket\"}}");
-					}
-
-					return new UnbakedDynamicModel(DynamicBucketBakedModel::new);
-				}
-
-				return null;
-			});
-			*/
-		});
+		ItemModelTypes.ID_MAPPER.put(ItemCellModel.ID, ItemCellModel.Unbaked.CODEC);
+		ItemModelTypes.ID_MAPPER.put(ItemBucketModel.ID, ItemBucketModel.Unbaked.CODEC);
 
 		KeyBindings.registerKeys();
 
@@ -250,18 +208,4 @@ public class TechRebornClient implements ClientModInitializer {
 		}
 
 	}
-
-	/*
-	private record UnbakedDynamicModel(Supplier<BaseDynamicFluidBakedModel> supplier) implements UnbakedModel {
-		@Override
-		public BakedModel bake(ModelTextures textures, Baker baker, ModelBakeSettings settings, boolean ambientOcclusion, boolean isSideLit, ModelTransformation transformation) {
-			return supplier.get();
-		}
-
-		@Override
-		public void resolve(Resolver resolver) {
-
-		}
-	}
-	*/
 }

--- a/src/client/java/techreborn/client/render/BaseDynamicFluidBakedModel.java
+++ b/src/client/java/techreborn/client/render/BaseDynamicFluidBakedModel.java
@@ -24,26 +24,21 @@
 
 package techreborn.client.render;
 
-/*
 import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
 import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
-import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
 import net.fabricmc.fabric.impl.client.indigo.renderer.helper.GeometryHelper;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.render.model.BakedModelManager;
 import net.minecraft.client.render.model.BakedQuad;
-import net.minecraft.client.render.model.json.ModelOverrideList;
 import net.minecraft.client.render.model.json.ModelTransformation;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.Fluids;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -51,31 +46,30 @@ import net.minecraft.util.math.random.Random;
 import net.minecraft.world.BlockRenderView;
 import org.jetbrains.annotations.Nullable;
 import reborncore.client.RenderUtil;
-import reborncore.common.fluid.container.ItemFluidInfo;
 import reborncore.common.util.Color;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 public abstract class BaseDynamicFluidBakedModel implements BakedModel, FabricBakedModel {
+	public Fluid fluid;
+	public BakedModel baseModel;
+	public BakedModel backgroundModel;
+	public BakedModel fluidModel;
 
-	public abstract Identifier getBaseModel();
-
-	public abstract Identifier getBackgroundModel();
-
-	public abstract Identifier getFluidModel();
+	BaseDynamicFluidBakedModel(Fluid fluid, BakedModel baseModel, BakedModel fluidModel, BakedModel backgroundModel) {
+		this.fluid = fluid;
+		this.baseModel = baseModel;
+		this.backgroundModel = backgroundModel;
+		this.fluidModel = fluidModel;
+	}
 
 	@Override
-	public void emitItemQuads(ItemStack stack, Supplier<Random> randomSupplier, RenderContext context) {
-		Fluid fluid = Fluids.EMPTY;
-		if (stack.getItem() instanceof ItemFluidInfo fluidInfo) {
-			fluid = fluidInfo.getFluid(stack);
-		}
-
-		BakedModelManager bakedModelManager = MinecraftClient.getInstance().getBakedModelManager();
-		bakedModelManager.getModel(getBaseModel()).emitItemQuads(stack, randomSupplier, context);
-		bakedModelManager.getModel(getBackgroundModel()).emitItemQuads(stack, randomSupplier, context);
+	public void emitItemQuads(QuadEmitter emitter, Supplier<Random> randomSupplier) {
+		baseModel.emitItemQuads(emitter, randomSupplier);
+		backgroundModel.emitItemQuads(emitter, randomSupplier);
 
 		if (fluid == Fluids.EMPTY) {
 			return;
@@ -94,11 +88,10 @@ public abstract class BaseDynamicFluidBakedModel implements BakedModel, FabricBa
 
 		int fluidColor = fluidRenderHandler.getFluidColor(MinecraftClient.getInstance().world, player.getBlockPos(), fluid.getDefaultState());
 		Sprite fluidSprite = fluidRenderHandler.getFluidSprites(MinecraftClient.getInstance().world, BlockPos.ORIGIN, fluid.getDefaultState())[0];
-		BakedModel fluidModel = bakedModelManager.getModel(getFluidModel());
 
 		int color = new Color((float) (fluidColor >> 16 & 255) / 255.0F, (float) (fluidColor >> 8 & 255) / 255.0F, (float) (fluidColor & 255) / 255.0F).getColor();
 
-		context.pushTransform(quad -> {
+		emitter.pushTransform(quad -> {
 			quad.nominalFace(GeometryHelper.lightFace(quad));
 			quad.color(color, color, color, color);
 			// Some modded fluids doesn't have sprites. Fix for #2429
@@ -111,16 +104,15 @@ public abstract class BaseDynamicFluidBakedModel implements BakedModel, FabricBa
 
 			return true;
 		});
-		final QuadEmitter emitter = context.getEmitter();
 		fluidModel.getQuads(null, null, randomSupplier.get()).forEach(q -> {
 			emitter.fromVanilla(q.getVertexData(), 0);
 			emitter.emit();
 		});
-		context.popTransform();
+		emitter.popTransform();
 	}
 
 	@Override
-	public void emitBlockQuads(BlockRenderView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
+	public void emitBlockQuads(QuadEmitter emitter, BlockRenderView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, Predicate<@Nullable Direction> cullTest) {
 
 	}
 
@@ -145,18 +137,8 @@ public abstract class BaseDynamicFluidBakedModel implements BakedModel, FabricBa
 	}
 
 	@Override
-	public boolean isBuiltin() {
-		return false;
-	}
-
-	@Override
 	public ModelTransformation getTransformation() {
 		return ModelHelper.DEFAULT_ITEM_TRANSFORMS;
-	}
-
-	@Override
-	public ModelOverrideList getOverrides() {
-		return ModelOverrideList.EMPTY;
 	}
 
 	@Override
@@ -165,4 +147,3 @@ public abstract class BaseDynamicFluidBakedModel implements BakedModel, FabricBa
 	}
 
 }
-*/

--- a/src/client/java/techreborn/client/render/DynamicBucketBakedModel.java
+++ b/src/client/java/techreborn/client/render/DynamicBucketBakedModel.java
@@ -24,10 +24,11 @@
 
 package techreborn.client.render;
 
-/*
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
+import net.minecraft.fluid.Fluid;
 import net.minecraft.util.Identifier;
 import techreborn.TechReborn;
 
@@ -36,26 +37,14 @@ public class DynamicBucketBakedModel extends BaseDynamicFluidBakedModel {
 	public static final Identifier BUCKET_BACKGROUND = Identifier.of(TechReborn.MOD_ID, "item/bucket_background");
 	public static final Identifier BUCKET_FLUID = Identifier.of(TechReborn.MOD_ID, "item/bucket_fluid");
 
+	DynamicBucketBakedModel(Fluid fluid, BakedModel baseModel, BakedModel fluidModel, BakedModel backgroundModel) {
+		super(fluid, baseModel, fluidModel, backgroundModel);
+	}
+
 	@Override
 	public Sprite getParticleSprite() {
 		return MinecraftClient.getInstance()
 				.getSpriteAtlas(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE)
 				.apply(Identifier.of("minecraft:item/bucket"));
 	}
-
-	@Override
-	public Identifier getBaseModel() {
-		return BUCKET_BASE;
-	}
-
-	@Override
-	public Identifier getBackgroundModel() {
-		return BUCKET_BACKGROUND;
-	}
-
-	@Override
-	public Identifier getFluidModel() {
-		return BUCKET_FLUID;
-	}
 }
-*/

--- a/src/client/java/techreborn/client/render/DynamicCellBakedModel.java
+++ b/src/client/java/techreborn/client/render/DynamicCellBakedModel.java
@@ -24,13 +24,12 @@
 
 package techreborn.client.render;
 
-/*
-import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.render.model.BakedModelManager;
+import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.texture.Sprite;
-import net.minecraft.item.ItemStack;
 import net.minecraft.client.texture.SpriteAtlasTexture;
+import net.minecraft.fluid.Fluids;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.random.Random;
 import techreborn.TechReborn;
@@ -42,13 +41,17 @@ public class DynamicCellBakedModel extends BaseDynamicFluidBakedModel {
 	public static final Identifier CELL_BACKGROUND = Identifier.of(TechReborn.MOD_ID, "item/cell_background");
 	public static final Identifier CELL_FLUID = Identifier.of(TechReborn.MOD_ID, "item/cell_fluid");
 	public static final Identifier CELL_GLASS = Identifier.of(TechReborn.MOD_ID, "item/cell_glass");
+	private final BakedModel glassModel;
+
+	public DynamicCellBakedModel(BakedModel baseModel, BakedModel fluidModel, BakedModel backgroundModel, BakedModel glassModel) {
+		super(Fluids.EMPTY, baseModel, fluidModel, backgroundModel);
+		this.glassModel = glassModel;
+	}
 
 	@Override
-	public void emitItemQuads(ItemStack stack, Supplier<Random> randomSupplier, RenderContext context) {
-		super.emitItemQuads(stack, randomSupplier, context);
-
-		BakedModelManager bakedModelManager = MinecraftClient.getInstance().getBakedModelManager();
-		bakedModelManager.getModel(CELL_GLASS).emitItemQuads(stack, randomSupplier, context);
+	public void emitItemQuads(QuadEmitter emitter, Supplier<Random> randomSupplier) {
+		super.emitItemQuads(emitter, randomSupplier);
+		glassModel.emitItemQuads(emitter, randomSupplier);
 	}
 
 	@Override
@@ -57,20 +60,4 @@ public class DynamicCellBakedModel extends BaseDynamicFluidBakedModel {
 				.getSpriteAtlas(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE)
 				.apply(Identifier.of("techreborn:item/cell_base"));
 	}
-
-	@Override
-	public Identifier getBaseModel() {
-		return CELL_BASE;
-	}
-
-	@Override
-	public Identifier getBackgroundModel() {
-		return CELL_BACKGROUND;
-	}
-
-	@Override
-	public Identifier getFluidModel() {
-		return CELL_FLUID;
-	}
 }
-*/

--- a/src/client/java/techreborn/client/render/ItemBucketModel.java
+++ b/src/client/java/techreborn/client/render/ItemBucketModel.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of TechReborn, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2020 TechReborn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package techreborn.client.render;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.client.item.ItemModelManager;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.RenderLayers;
+import net.minecraft.client.render.item.ItemRenderState;
+import net.minecraft.client.render.item.model.ItemModel;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ModelTransformationMode;
+import net.minecraft.registry.Registries;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
+import techreborn.TechReborn;
+
+import java.util.HashMap;
+
+public class ItemBucketModel implements ItemModel {
+	public static final Identifier ID = Identifier.of(TechReborn.MOD_ID, "model/bucket");
+	private final DynamicBucketBakedModel model;
+	ItemBucketModel(Fluid fluid, BakedModel baseModel, BakedModel fluidModel, BakedModel backgroundModel) {
+		model = new DynamicBucketBakedModel(fluid, baseModel, fluidModel, backgroundModel);
+	}
+
+	@Override
+	public void update(ItemRenderState state, ItemStack stack, ItemModelManager resolver, ModelTransformationMode transformationMode, @Nullable ClientWorld world, @Nullable LivingEntity user, int seed) {
+		ItemRenderState.LayerRenderState layerRenderState = state.newLayer();
+		RenderLayer renderLayer = RenderLayers.getItemLayer(stack);
+		layerRenderState.setModel(model, renderLayer);
+	}
+
+	public record Unbaked(Fluid fluid) implements ItemModel.Unbaked {
+		public static final MapCodec<ItemBucketModel.Unbaked> CODEC = RecordCodecBuilder.mapCodec(
+			instance -> instance.group(
+				Identifier.CODEC.xmap(Registries.FLUID::get, Registries.FLUID::getId)
+					.fieldOf("fluid").forGetter(Unbaked::fluid)
+			)
+			.apply(instance, ItemBucketModel.Unbaked::new)
+		);
+		private static final HashMap<Identifier, BakedModel> CACHE = new HashMap<>();
+
+		@Override
+		public void resolve(Resolver resolver) {
+			resolver.resolve(DynamicBucketBakedModel.BUCKET_BASE);
+			resolver.resolve(DynamicBucketBakedModel.BUCKET_FLUID);
+			resolver.resolve(DynamicBucketBakedModel.BUCKET_BACKGROUND);
+		}
+
+		@Override
+		public ItemModel bake(BakeContext context) {
+			BakedModel baseModel = CACHE.computeIfAbsent(DynamicBucketBakedModel.BUCKET_BASE, context::bake);
+			BakedModel fluidModel = CACHE.computeIfAbsent(DynamicBucketBakedModel.BUCKET_FLUID, context::bake);
+			BakedModel backgroundModel = CACHE.computeIfAbsent(DynamicBucketBakedModel.BUCKET_BACKGROUND, context::bake);
+			return new ItemBucketModel(fluid, baseModel, fluidModel, backgroundModel);
+		}
+
+		@Override
+		public MapCodec<ItemBucketModel.Unbaked> getCodec() {
+			return CODEC;
+		}
+	}
+}

--- a/src/client/java/techreborn/client/render/ItemCellModel.java
+++ b/src/client/java/techreborn/client/render/ItemCellModel.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of TechReborn, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2020 TechReborn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package techreborn.client.render;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.client.item.ItemModelManager;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.RenderLayers;
+import net.minecraft.client.render.item.ItemRenderState;
+import net.minecraft.client.render.item.model.ItemModel;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.ResolvableModel;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ModelTransformationMode;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
+import reborncore.common.fluid.container.ItemFluidInfo;
+import techreborn.TechReborn;
+
+import java.util.HashMap;
+
+public class ItemCellModel implements ItemModel {
+	public static final Identifier ID = Identifier.of(TechReborn.MOD_ID, "model/cell");
+	private final DynamicCellBakedModel model;
+	ItemCellModel(BakedModel baseModel, BakedModel fluidModel, BakedModel backgroundModel, BakedModel glassModel) {
+		model = new DynamicCellBakedModel(baseModel, fluidModel, backgroundModel, glassModel);
+	}
+
+	@Override
+	public void update(ItemRenderState state, ItemStack stack, ItemModelManager resolver, ModelTransformationMode transformationMode, @Nullable ClientWorld world, @Nullable LivingEntity user, int seed) {
+		ItemRenderState.LayerRenderState layerRenderState = state.newLayer();
+
+		Fluid fluid = Fluids.EMPTY;
+		if (stack.getItem() instanceof ItemFluidInfo fluidInfo) {
+			fluid = fluidInfo.getFluid(stack);
+		}
+		model.fluid = fluid;
+
+		RenderLayer renderLayer = RenderLayers.getItemLayer(stack);
+		layerRenderState.setModel(model, renderLayer);
+	}
+
+	public record Unbaked() implements ItemModel.Unbaked {
+		public static final MapCodec<ItemCellModel.Unbaked> CODEC = MapCodec.unit(ItemCellModel.Unbaked::new);
+		private static final HashMap<Identifier, BakedModel> CACHE = new HashMap<>();
+
+		@Override
+		public void resolve(ResolvableModel.Resolver resolver) {
+			resolver.resolve(DynamicCellBakedModel.CELL_BASE);
+			resolver.resolve(DynamicCellBakedModel.CELL_BACKGROUND);
+			resolver.resolve(DynamicCellBakedModel.CELL_FLUID);
+			resolver.resolve(DynamicCellBakedModel.CELL_GLASS);
+		}
+
+		@Override
+		public ItemModel bake(ItemModel.BakeContext context) {
+			BakedModel baseModel = CACHE.computeIfAbsent(DynamicCellBakedModel.CELL_BASE, context::bake);
+			BakedModel fluidModel = CACHE.computeIfAbsent(DynamicCellBakedModel.CELL_FLUID, context::bake);
+			BakedModel backgroundModel = CACHE.computeIfAbsent(DynamicCellBakedModel.CELL_BACKGROUND, context::bake);
+			BakedModel glassModel = CACHE.computeIfAbsent(DynamicCellBakedModel.CELL_GLASS, context::bake);
+			return new ItemCellModel(baseModel, fluidModel, backgroundModel, glassModel);
+		}
+
+		@Override
+		public MapCodec<ItemCellModel.Unbaked> getCodec() {
+			return CODEC;
+		}
+	}
+}

--- a/src/main/resources/assets/techreborn/items/beryllium_bucket.json
+++ b/src/main/resources/assets/techreborn/items/beryllium_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:beryllium"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/biofuel_bucket.json
+++ b/src/main/resources/assets/techreborn/items/biofuel_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:biofuel"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/calcium_bucket.json
+++ b/src/main/resources/assets/techreborn/items/calcium_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:calcium"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/calcium_carbonate_bucket.json
+++ b/src/main/resources/assets/techreborn/items/calcium_carbonate_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:calcium_carbonate"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/carbon_bucket.json
+++ b/src/main/resources/assets/techreborn/items/carbon_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:carbon"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/carbon_fiber_bucket.json
+++ b/src/main/resources/assets/techreborn/items/carbon_fiber_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:carbon_fiber"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/cell.json
+++ b/src/main/resources/assets/techreborn/items/cell.json
@@ -1,0 +1,5 @@
+{
+  "model": {
+    "type": "techreborn:model/cell"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/chlorite_bucket.json
+++ b/src/main/resources/assets/techreborn/items/chlorite_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:chlorite"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/compressed_air_bucket.json
+++ b/src/main/resources/assets/techreborn/items/compressed_air_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:compressed_air"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/deuterium_bucket.json
+++ b/src/main/resources/assets/techreborn/items/deuterium_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:deuterium"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/diesel_bucket.json
+++ b/src/main/resources/assets/techreborn/items/diesel_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:diesel"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/electrolyzed_water_bucket.json
+++ b/src/main/resources/assets/techreborn/items/electrolyzed_water_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:electrolyzed_water"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/glyceryl_bucket.json
+++ b/src/main/resources/assets/techreborn/items/glyceryl_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:glyceryl"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/helium3_bucket.json
+++ b/src/main/resources/assets/techreborn/items/helium3_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:helium3"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/helium_bucket.json
+++ b/src/main/resources/assets/techreborn/items/helium_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:helium"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/heliumplasma_bucket.json
+++ b/src/main/resources/assets/techreborn/items/heliumplasma_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:heliumplasma"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/hydrogen_bucket.json
+++ b/src/main/resources/assets/techreborn/items/hydrogen_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:hydrogen"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/lithium_bucket.json
+++ b/src/main/resources/assets/techreborn/items/lithium_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:lithium"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/mercury_bucket.json
+++ b/src/main/resources/assets/techreborn/items/mercury_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:mercury"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/methane_bucket.json
+++ b/src/main/resources/assets/techreborn/items/methane_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:methane"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/nitro_carbon_bucket.json
+++ b/src/main/resources/assets/techreborn/items/nitro_carbon_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:nitro_carbon"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/nitro_diesel_bucket.json
+++ b/src/main/resources/assets/techreborn/items/nitro_diesel_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:nitro_diesel"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/nitrocoal_fuel_bucket.json
+++ b/src/main/resources/assets/techreborn/items/nitrocoal_fuel_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:nitrocoal_fuel"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/nitrofuel_bucket.json
+++ b/src/main/resources/assets/techreborn/items/nitrofuel_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:nitrofuel"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/nitrogen_bucket.json
+++ b/src/main/resources/assets/techreborn/items/nitrogen_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:nitrogen"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/nitrogen_dioxide_bucket.json
+++ b/src/main/resources/assets/techreborn/items/nitrogen_dioxide_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:nitrogen_dioxide"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/oil_bucket.json
+++ b/src/main/resources/assets/techreborn/items/oil_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:oil"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/potassium_bucket.json
+++ b/src/main/resources/assets/techreborn/items/potassium_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:potassium"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/silicon_bucket.json
+++ b/src/main/resources/assets/techreborn/items/silicon_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:silicon"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/sodium_bucket.json
+++ b/src/main/resources/assets/techreborn/items/sodium_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:sodium"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/sodium_persulfate_bucket.json
+++ b/src/main/resources/assets/techreborn/items/sodium_persulfate_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:sodium_persulfate"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/sodium_sulfide_bucket.json
+++ b/src/main/resources/assets/techreborn/items/sodium_sulfide_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:sodium_sulfide"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/sulfur_bucket.json
+++ b/src/main/resources/assets/techreborn/items/sulfur_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:sulfur"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/sulfuric_acid_bucket.json
+++ b/src/main/resources/assets/techreborn/items/sulfuric_acid_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:sulfuric_acid"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/tritium_bucket.json
+++ b/src/main/resources/assets/techreborn/items/tritium_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:tritium"
+  }
+}

--- a/src/main/resources/assets/techreborn/items/wolframium_bucket.json
+++ b/src/main/resources/assets/techreborn/items/wolframium_bucket.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "techreborn:model/bucket",
+    "fluid": "techreborn:wolframium"
+  }
+}

--- a/src/main/resources/assets/techreborn/models/item/bucket_background.json
+++ b/src/main/resources/assets/techreborn/models/item/bucket_background.json
@@ -1,6 +1,7 @@
 {
 	"parent": "techreborn:item/bucket_fluid_template",
 	"textures": {
-		"texture": "techreborn:item/bucket_background"
+		"texture": "techreborn:item/bucket_background",
+		"particle": "#texture"
 	}
 }

--- a/src/main/resources/assets/techreborn/models/item/bucket_base.json
+++ b/src/main/resources/assets/techreborn/models/item/bucket_base.json
@@ -1,6 +1,7 @@
 {
   "parent": "minecraft:item/generated",
   "textures": {
-    "layer0": "techreborn:item/bucket_base"
+    "layer0": "techreborn:item/bucket_base",
+    "particle": "#layer0"
   }
 }

--- a/src/main/resources/assets/techreborn/models/item/bucket_fluid.json
+++ b/src/main/resources/assets/techreborn/models/item/bucket_fluid.json
@@ -1,6 +1,7 @@
 {
 	"parent": "techreborn:item/bucket_fluid_template",
 	"textures": {
-		"texture": "techreborn:item/bucket_background"
+		"texture": "techreborn:item/bucket_background",
+		"particle": "#texture"
 	}
 }

--- a/src/main/resources/assets/techreborn/models/item/cell_background.json
+++ b/src/main/resources/assets/techreborn/models/item/cell_background.json
@@ -1,6 +1,7 @@
 {
 	"parent": "techreborn:item/cell_fluid_template",
 	"textures": {
-		"texture": "techreborn:item/cell_background"
+		"texture": "techreborn:item/cell_background",
+		"particle": "#texture"
 	}
 }

--- a/src/main/resources/assets/techreborn/models/item/cell_base.json
+++ b/src/main/resources/assets/techreborn/models/item/cell_base.json
@@ -1,6 +1,7 @@
 {
   "parent": "minecraft:item/generated",
   "textures": {
-    "layer0": "techreborn:item/cell_base"
+    "layer0": "techreborn:item/cell_base",
+    "particle": "#layer0"
   }
 }

--- a/src/main/resources/assets/techreborn/models/item/cell_fluid.json
+++ b/src/main/resources/assets/techreborn/models/item/cell_fluid.json
@@ -1,6 +1,7 @@
 {
 	"parent": "techreborn:item/cell_fluid_template",
 	"textures": {
-		"texture": "techreborn:item/cell_background"
+		"texture": "techreborn:item/cell_background",
+		"particle": "#texture"
 	}
 }

--- a/src/main/resources/assets/techreborn/models/item/cell_glass.json
+++ b/src/main/resources/assets/techreborn/models/item/cell_glass.json
@@ -1,6 +1,7 @@
 {
   "parent": "techreborn:item/cell_fluid_template",
   "textures": {
-    "texture": "techreborn:item/cell_glass"
+    "texture": "techreborn:item/cell_glass",
+    "particle": "#texture"
   }
 }


### PR DESCRIPTION
Added `techreborn:model/cell` and `techreborn:model/bucket` models
## Why use json files?
- Because ModelLoadingPlugin cannot dynamically add item models to `ModelBaker.itemAssets`, and `itemAssets.forEach` is used during bake and the model cannot be rendered.
## Why not use ModelLoadingPlugin?
- ItemModel.Unbaked can resolve externally dependent `GLASS`, `BASE`, `BACKGROUND`, and `FLUID`
- The update function of ItemModel can obtain the `ItemStack` that the plugin cannot obtain.