### PR TITLE
Port/1.21.4 Fix power bar energy display

### DIFF
--- a/RebornCore/src/client/java/reborncore/client/gui/GuiBuilder.java
+++ b/RebornCore/src/client/java/reborncore/client/gui/GuiBuilder.java
@@ -499,7 +499,7 @@ public class GuiBuilder {
 		if (energyStored > maxEnergyStored) {
 			draw = barHeight;
 		}
-		drawSprite(drawContext, GuiSprites.POWER_BAR_OVERLAY, x + 1, y + 49 - draw, 12, draw, gui);
+		drawSprite(drawContext, GuiSprites.POWER_BAR_OVERLAY, x + 1, y + 49 - draw, 12, draw);
 
 		int percentage = percentage(maxEnergyStored, energyStored);
 		if (gui.isPointInRect(x + 1, y + 1, 11, 48, mouseX, mouseY)) {


### PR DESCRIPTION
Cancel the scissor effect of power_bar_overlay
I don't know why it can't be displayed, just delete it.