### PR TITLE
Fix fusion control computer recipe energy consumed

### DIFF
--- a/src/main/java/techreborn/blockentity/machine/multiblock/FusionControlComputerBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/multiblock/FusionControlComputerBlockEntity.java
@@ -294,18 +294,17 @@ public class FusionControlComputerBlockEntity extends GenericMachineBlockEntity 
 				}
 			}
 			if (hasStartedCrafting && craftingTickTime < currentRecipe.time()) {
+				int recipePower = currentRecipe.power();
 				// Power gen
-				if (currentRecipe.power() > 0) {
+				if (recipePower > 0) {
 					// Waste power if it has nowhere to go
 					long power = (long) (Math.abs(currentRecipe.power()) * getPowerMultiplier());
 					addEnergy(power);
 					powerChange = (power);
 					craftingTickTime++;
-				} else { // Power user
-					if (getStored() > currentRecipe.power()) {
-						setEnergy(getEnergy() - currentRecipe.power());
-						craftingTickTime++;
-					}
+				} else if (getStored() > -recipePower) { // Power user
+					setEnergy(getEnergy() + recipePower);
+					craftingTickTime++;
 				}
 			} else if (craftingTickTime >= currentRecipe.time()) {
 				ItemStack result = currentRecipe.outputs().getFirst();


### PR DESCRIPTION
The recipe is inconsistent with the [wiki](https://wiki.techreborn.ovh/doku.php?id=energy:generators:fusion_control_computer&redirect=1#fuel_input) description.
![wiki](https://github.com/user-attachments/assets/ec1737ac-b89c-4148-b6db-a8cb6d953e3c)
Revert errors caused by the following commits (1.15-3.0.25+)
https://github.com/TechReborn/TechReborn/commit/a0fbc1ccb3dbb32452b3fa72c8c7bb76d82a0578#diff-a360b97bebf681f48585c9cbc42ff8bf4ec7df06e1a2459d93f3453c46caa1cdR284-R287
```diff
} else { // Power user
-	if (canUseEnergy(currentRecipe.getPower() * -1)) {
+	if (canUseEnergy(currentRecipe.getPower())) {
-		setEnergy(getEnergy() - currentRecipe.getPower() * -1);
+		setEnergy(getEnergy() - currentRecipe.getPower());
+		crafingTickTime++;
	}
}
```