### PR TITLE
Make Auto Crafting Table upgradable

### DIFF
--- a/src/main/java/techreborn/blockentity/machine/tier1/AutoCraftingTableBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/tier1/AutoCraftingTableBlockEntity.java
@@ -76,8 +76,9 @@ public class AutoCraftingTableBlockEntity extends PowerAcceptorBlockEntity
 	private final int OUTPUT_SLOT = CRAFTING_AREA; // first slot is indexed by 0, so this is the last non crafting slot
 	private final int EXTRA_OUTPUT_SLOT = CRAFTING_AREA + 1;
 
-	public int progress;
-	public int maxProgress = 120;
+	public int progress = 0;
+	public final int defaultMaxProgress = 120;
+	public int maxProgress = defaultMaxProgress; // changes based on speed upgrades
 	public final int euTick = 10;
 
 	CraftingInventory inventoryCrafting;
@@ -243,12 +244,13 @@ public class AutoCraftingTableBlockEntity extends PowerAcceptorBlockEntity
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
 		super.tick(world, pos, state, blockEntity);
-		if (world == null || world.isClient || getStored() < euTick) {
+		if (world == null || world.isClient || getStored() < getEuPerTick(euTick)) {
 			return;
 		}
 		if (inventoryCrafting.isEmpty()) {
 			if (progress == 0) return;
 			progress = 0;
+			maxProgress = Math.max((int) (defaultMaxProgress * (1.0 - getSpeedMultiplier())), 1);
 			outputPreview = ItemStack.EMPTY;
 			return;
 		}
@@ -256,6 +258,7 @@ public class AutoCraftingTableBlockEntity extends PowerAcceptorBlockEntity
 		CraftingRecipeInput input = positioned.input();
 		if (!updateCurrentRecipe(input) || !hasOutputSpace(outputPreview, OUTPUT_SLOT)) {
 			progress = 0;
+			maxProgress = Math.max((int) (defaultMaxProgress * (1.0 - getSpeedMultiplier())), 1);
 			return;
 		}
 
@@ -277,14 +280,15 @@ public class AutoCraftingTableBlockEntity extends PowerAcceptorBlockEntity
 
 		if (progress >= maxProgress) {
 			progress = 0;
+			maxProgress = Math.max((int) (defaultMaxProgress * (1.0 - getSpeedMultiplier())), 1);
 			make(positioned, outputPreview, recipeReminder);
 		} else {
 			progress++;
-			if (progress == 1) {
+			if (progress == 1 && !isMuffled()) {
 				world.playSound(null, pos.getX(), pos.getY(), pos.getZ(), ModSounds.AUTO_CRAFTING,
 					SoundCategory.BLOCKS, 0.3F, 0.8F);
 			}
-			useEnergy(euTick);
+			useEnergy(getEuPerTick(euTick));
 		}
 	}
 
@@ -325,7 +329,7 @@ public class AutoCraftingTableBlockEntity extends PowerAcceptorBlockEntity
 	// MachineBaseBlockEntity
 	@Override
 	public boolean canBeUpgraded() {
-		return false;
+		return true;
 	}
 
 	// IToolDrop

--- a/src/main/java/techreborn/blockentity/machine/tier1/AutoCraftingTableBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/tier1/AutoCraftingTableBlockEntity.java
@@ -70,6 +70,8 @@ public class AutoCraftingTableBlockEntity extends PowerAcceptorBlockEntity
 	public static final int CRAFTING_HEIGHT = 3;
 	public static final int CRAFTING_WIDTH = 3;
 	public static final int CRAFTING_AREA = CRAFTING_HEIGHT * CRAFTING_WIDTH;
+	public static final int RECIPE_TIME = 120;
+	public static final int EU_TICK = 10;
 
 	public final RebornInventory<AutoCraftingTableBlockEntity> inventory;
 	private final BalanceTable balanceTable = new BalanceTable();
@@ -77,9 +79,9 @@ public class AutoCraftingTableBlockEntity extends PowerAcceptorBlockEntity
 	private final int EXTRA_OUTPUT_SLOT = CRAFTING_AREA + 1;
 
 	public int progress = 0;
-	public final int defaultMaxProgress = 120;
-	public int maxProgress = defaultMaxProgress; // changes based on speed upgrades
-	public final int euTick = 10;
+	public int maxProgress = RECIPE_TIME;
+	public long euTick = EU_TICK;
+	public long lastSoundTime = 0;
 
 	CraftingInventory inventoryCrafting;
 	CraftingRecipe lastRecipe = null;
@@ -147,10 +149,7 @@ public class AutoCraftingTableBlockEntity extends PowerAcceptorBlockEntity
 		};
 	}
 
-	@Nullable
-	public boolean updateCurrentRecipe(CraftingRecipeInput input) {
-		if (!(world instanceof ServerWorld serverWorld)) return false;
-
+	public boolean updateCurrentRecipe(ServerWorld world, CraftingRecipeInput input) {
 		if (lastRecipe != null && lastRecipe.matches(input, world)) {
 			if (outputPreview == ItemStack.EMPTY) {
 				balanceTable.updateLayout(input);
@@ -162,7 +161,8 @@ public class AutoCraftingTableBlockEntity extends PowerAcceptorBlockEntity
 		}
 
 		if (balanceTable.updateLayout(input)) {
-			Optional<CraftingRecipe> testRecipe = serverWorld.getRecipeManager().getFirstMatch(RecipeType.CRAFTING, input, world).map(RecipeEntry::value);
+			Optional<CraftingRecipe> testRecipe = world.getRecipeManager()
+				.getFirstMatch(RecipeType.CRAFTING, input, world).map(RecipeEntry::value);
 			if (testRecipe.isPresent()) {
 				lastRecipe = testRecipe.get();
 				outputPreview = lastRecipe.craft(input, world.getRegistryManager());
@@ -215,9 +215,6 @@ public class AutoCraftingTableBlockEntity extends PowerAcceptorBlockEntity
 			moveOutput(remainderStack, EXTRA_OUTPUT_SLOT);
 		}
 		inventory.resetHasChanged();
-		if (inventoryCrafting.isEmpty()) {
-			outputPreview = ItemStack.EMPTY;
-		}
 	}
 
 	private boolean hasOutputSpace(ItemStack output, int slot) {
@@ -244,21 +241,21 @@ public class AutoCraftingTableBlockEntity extends PowerAcceptorBlockEntity
 	@Override
 	public void tick(World world, BlockPos pos, BlockState state, MachineBaseBlockEntity blockEntity) {
 		super.tick(world, pos, state, blockEntity);
-		if (world == null || world.isClient || getStored() < getEuPerTick(euTick)) {
+		if (world == null || world.isClient || getStored() < euTick) {
 			return;
 		}
 		if (inventoryCrafting.isEmpty()) {
-			if (progress == 0) return;
 			progress = 0;
-			maxProgress = Math.max((int) (defaultMaxProgress * (1.0 - getSpeedMultiplier())), 1);
 			outputPreview = ItemStack.EMPTY;
 			return;
 		}
 		CraftingRecipeInput.Positioned positioned = inventoryCrafting.createPositionedRecipeInput();
 		CraftingRecipeInput input = positioned.input();
-		if (!updateCurrentRecipe(input) || !hasOutputSpace(outputPreview, OUTPUT_SLOT)) {
+		if (!updateCurrentRecipe((ServerWorld) world, input)) {
 			progress = 0;
-			maxProgress = Math.max((int) (defaultMaxProgress * (1.0 - getSpeedMultiplier())), 1);
+			return;
+		}
+		if (!hasOutputSpace(outputPreview, OUTPUT_SLOT)) {
 			return;
 		}
 
@@ -280,15 +277,28 @@ public class AutoCraftingTableBlockEntity extends PowerAcceptorBlockEntity
 
 		if (progress >= maxProgress) {
 			progress = 0;
-			maxProgress = Math.max((int) (defaultMaxProgress * (1.0 - getSpeedMultiplier())), 1);
 			make(positioned, outputPreview, recipeReminder);
-		} else {
-			progress++;
-			if (progress == 1 && !isMuffled()) {
-				world.playSound(null, pos.getX(), pos.getY(), pos.getZ(), ModSounds.AUTO_CRAFTING,
-					SoundCategory.BLOCKS, 0.3F, 0.8F);
+			if (inventoryCrafting.isEmpty()) {
+				outputPreview = ItemStack.EMPTY;
 			}
-			useEnergy(getEuPerTick(euTick));
+		} else {
+			if (progress == 0) {
+				maxProgress = Math.max((int) (RECIPE_TIME * (1.0 - getSpeedMultiplier())), 1);
+				euTick = getEuPerTick(EU_TICK);
+				if (getStored() < euTick) {
+					return;
+				}
+			}
+			progress++;
+			if (!isMuffled()) {
+				long time = world.getTime();
+				if (time - lastSoundTime > RECIPE_TIME) {
+					lastSoundTime = time;
+					world.playSound(null, pos.getX(), pos.getY(), pos.getZ(), ModSounds.AUTO_CRAFTING,
+						SoundCategory.BLOCKS, 0.3F, 0.8F);
+				}
+			}
+			useEnergy(euTick);
 		}
 	}
 
@@ -324,12 +334,6 @@ public class AutoCraftingTableBlockEntity extends PowerAcceptorBlockEntity
 			locked = tag.getBoolean("locked");
 		}
 		super.readNbt(tag, registryLookup);
-	}
-
-	// MachineBaseBlockEntity
-	@Override
-	public boolean canBeUpgraded() {
-		return true;
 	}
 
 	// IToolDrop


### PR DESCRIPTION
While trying to automatize some processes in the game, I noticed that the Auto Crafting Table doesn't currently allow upgrading. This creates a bottleneck in automation processes, so I tried checking if there were some open issues here in the repo.

I found [this very old issue](https://github.com/TechReborn/TechReborn/issues/2402) that has been closed in favor of [this discussion](https://github.com/TechReborn/TechReborn/discussions/2533), but neither of them has had any activity.

For this reason, I decided to try adding support for upgrades by myself, based on how upgrades are handled on other machines. I added and checked support for all the upgrades, including muffler. Let me know if I'm missing something else. You can find some screenshots below.

**Upgrades UI**

![image](https://github.com/user-attachments/assets/5156ddb2-1801-4189-9cd9-f643c4daaa4e)

**Energy storage + transformer upgrades**

![image](https://github.com/user-attachments/assets/7a757aef-87ad-428c-a441-edb508ca1628)

**Overclocker upgrades**

![Screen Recording 2025-02-23 at 15 49 57](https://github.com/user-attachments/assets/e296f228-c3ee-46cc-9418-c62bb17a256d)
