### PR TITLE
Fixes recycler crafting chance

### DIFF
--- a/src/main/java/techreborn/recipe/RecyclerRecipeCrafter.java
+++ b/src/main/java/techreborn/recipe/RecyclerRecipeCrafter.java
@@ -26,6 +26,8 @@ package techreborn.recipe;
 
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.World;
 import reborncore.common.crafting.RebornRecipe;
 import reborncore.common.crafting.RecipeUtils;
 import reborncore.common.recipes.RecipeCrafter;
@@ -84,9 +86,11 @@ public class RecyclerRecipeCrafter extends RecipeCrafter {
 
 	@Override
 	public void fitStack(ItemStack stack, int slot) {
-		// Dirtier hack for chance based crafting
-		final int randomChance = Objects.requireNonNull(blockEntity.getWorld()).random.nextInt(TechRebornConfig.recyclerChance + 1);
-		if (randomChance == 1) {
+		final World world = Objects.requireNonNull(blockEntity.getWorld());
+		final Random random = world.random;
+
+		final int randomChance = random.nextInt(TechRebornConfig.recyclerChance);
+		if (randomChance == 0) {
 			super.fitStack(stack, slot);
 		}
 	}

--- a/src/main/java/techreborn/recipe/RecyclerRecipeCrafter.java
+++ b/src/main/java/techreborn/recipe/RecyclerRecipeCrafter.java
@@ -84,8 +84,8 @@ public class RecyclerRecipeCrafter extends RecipeCrafter {
 
 	@Override
 	public void fitStack(ItemStack stack, int slot) {
-		// Dirty hack for chance based crafting
-		final int randomChance = Objects.requireNonNull(blockEntity.getWorld()).random.nextInt(TechRebornConfig.recyclerChance);
+		// Dirtier hack for chance based crafting
+		final int randomChance = Objects.requireNonNull(blockEntity.getWorld()).random.nextInt(TechRebornConfig.recyclerChance + 1);
 		if (randomChance == 1) {
 			super.fitStack(stack, slot);
 		}


### PR DESCRIPTION
nextInt is not inclusive so if the chance is set to be 1/1 it would always generated 0

I changed the comparison to zero since it will always include a 0
and did a smidge of cleanup

![image](https://github.com/user-attachments/assets/7f115406-9ee3-4c94-b39d-2e3aafd2b37d)
Tested on 1.21.4 with the chance set to 1/1 (1/6 make ~11 scrap)