### PR TITLE
Break out of iteration after setting iterator to `null`

### DIFF
--- a/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/cable/CableBlockEntity.java
@@ -209,6 +209,7 @@ public class CableBlockEntity extends BlockEntity
 				// Schedule a rebuild next tick.
 				// This is just a reference change, the iterator remains valid.
 				targets = null;
+				break;
 			} else {
 				targetStorages.add(new OfferedEnergyStorage(this, target.directionTo, storage));
 			}


### PR DESCRIPTION
This change is necessary because otherwise, in case the loop would continue, the game will [crash](https://mpaste.ntms.link/paste/?content=https%3A%2F%2Fcdn.discordapp.com%2Fattachments%2F1281630168552702022%2F1369899409562931220%2Fcrash-2025-04-29_07.43.29-server.txt&raw=true) because the iteration target of the `foreach` loop is now null.