### PR TITLE
Proposed fix for : Player Detector range measured from corner of block not center #3427

### DIFF
--- a/src/main/java/techreborn/blockentity/machine/tier1/PlayerDetectorBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/machine/tier1/PlayerDetectorBlockEntity.java
@@ -94,7 +94,7 @@ public class PlayerDetectorBlockEntity extends PowerAcceptorBlockEntity implemen
 				if (player.isSpectator()){
 					continue;
 				}
-				if (MathHelper.sqrt((float)player.squaredDistanceTo(pos.getX(), pos.getY(), pos.getZ())) <= (float)radius ) {
+				if (MathHelper.sqrt((float)player.squaredDistanceTo(pos.getX() +0.5f, pos.getY() +0.5f, pos.getZ() +0.5f)) <= (float)radius ) {
 					PlayerDetectorType type = world.getBlockState(pos).get(PlayerDetectorBlock.TYPE);
 					if (type == PlayerDetectorType.ALL) {// ALL
 						redstone = true;


### PR DESCRIPTION
Fix for bug :

Player Detector range measured from corner of block not center #3427


Added offset so distance calculation taken from center of block not the corner