### PR TITLE
Fix recipes making cells duplicate/disappear

### DIFF
--- a/src/datagen/groovy/techreborn/datagen/recipes/machine/blast_furnace/BlastFurnaceRecipesProvider.groovy
+++ b/src/datagen/groovy/techreborn/datagen/recipes/machine/blast_furnace/BlastFurnaceRecipesProvider.groovy
@@ -518,7 +518,7 @@ class BlastFurnaceRecipesProvider extends TechRebornRecipesProvider {
 			ingredient {
 				stack cellStack(ModFluids.CARBON, 5)
 			}
-			outputs stack(Items.SOUL_SAND, 8)
+			outputs stack(Items.SOUL_SAND, 8), stack(TRContent.CELL, 5)
 		}
 		offerBlastFurnaceRecipe {
 			power 128

--- a/src/datagen/groovy/techreborn/datagen/recipes/machine/industrial_electrolyzer/IndustrialElectrolyzerRecipesProvider.groovy
+++ b/src/datagen/groovy/techreborn/datagen/recipes/machine/industrial_electrolyzer/IndustrialElectrolyzerRecipesProvider.groovy
@@ -110,7 +110,7 @@ class IndustrialElectrolyzerRecipesProvider extends TechRebornRecipesProvider {
 			power 50
 			time 1400
 			ingredients stack(TRContent.Dusts.COAL), cellStack(Fluids.EMPTY)
-			outputs cellStack(ModFluids.CARBON, 2)
+			outputs cellStack(ModFluids.CARBON)
 		}
 		offerIndustrialElectrolyzerRecipe {
 			power 50
@@ -133,7 +133,7 @@ class IndustrialElectrolyzerRecipesProvider extends TechRebornRecipesProvider {
 		offerIndustrialElectrolyzerRecipe {
 			power 50
 			time 1100
-			ingredients stack(TRContent.Dusts.FLINT, 8), cellStack(Fluids.EMPTY)
+			ingredients stack(TRContent.Dusts.FLINT, 8), cellStack(Fluids.EMPTY, 2)
 			outputs cellStack(ModFluids.SILICON), cellStack(ModFluids.COMPRESSED_AIR)
 		}
 		offerIndustrialElectrolyzerRecipe {
@@ -205,7 +205,7 @@ class IndustrialElectrolyzerRecipesProvider extends TechRebornRecipesProvider {
 		offerIndustrialElectrolyzerRecipe {
 			power 40
 			time 1000
-			ingredients stack(Items.SAND, 16), cellStack(Fluids.EMPTY)
+			ingredients stack(Items.SAND, 16), cellStack(Fluids.EMPTY, 2)
 			outputs cellStack(ModFluids.SILICON), cellStack(ModFluids.COMPRESSED_AIR)
 		}
 		offerIndustrialElectrolyzerRecipe {


### PR DESCRIPTION
This pull request fixes problematic recipes involving cells in the Industrial Electrolyzer and in the Blast Furnace. This are the recipes that I've found, not sure if there are other recipes that have the same issues.

For the Coal -> Carbon Cell recipe, I aligned it to the same Charcoal recipe by making the output a single Carbon Cell, while for the Flint & Sand -> Silicon recipe I added an extra empty cell in the input, leaving the same output. Alternatively, it's also possible to leave the input as it is and remove the Compressed Air Cell in the output, but I thought it made more sense in this way.

For the Blast Furnace recipe, I simply added the missing 5 Empty Cells in the output.

Fixes #3473 