### PR TITLE
fix: SolarPanelBlockEntity#getGenerationRate

### DIFF
--- a/src/main/java/techreborn/blockentity/generator/SolarPanelBlockEntity.java
+++ b/src/main/java/techreborn/blockentity/generator/SolarPanelBlockEntity.java
@@ -124,7 +124,7 @@ public class SolarPanelBlockEntity extends PowerAcceptorBlockEntity implements I
 		// Ok, we are actively generating power, but check for a few conditions that would restrict
 		// the generation to minimal production...
 		if (!level.dimensionType().hasSkyLight() || // No light source in dimension (e.g. nether or end)
-			(skyAngle > 0.25 && skyAngle < 0.75) || // Light source is below horizon
+			(skyAngle > 0.5) || // Light source is below horizon
 			(level.isRaining() || level.isThundering())) { // Weather is present
 			return getPanel().generationRateN;
 		}
@@ -133,12 +133,12 @@ public class SolarPanelBlockEntity extends PowerAcceptorBlockEntity implements I
 		// the level of generation based on % of time through the day, with peak production at noon and
 		// a smooth transition to night production as sun rises/sets
 		float multiplier;
-		if (skyAngle > 0.75) {
+		if (skyAngle < 0.25) {
 			// Morning to noon
-			multiplier = (0.25f - (1 - skyAngle)) / 0.25f;
+			multiplier = skyAngle / 0.25f;
 		} else {
 			// Noon to sunset
-			multiplier = (0.25f - skyAngle) / 0.25f;
+			multiplier = (0.5f - skyAngle) / 0.25f;
 		}
 
 		return (int)Math.ceil(getPanel().generationRateN + (dayNightRange * multiplier));


### PR DESCRIPTION
Before fix, skyAngle got values 0 at sunrise, 0.25 at noon, 0.5 at sunset, 0.75 at midnight and so at line 127: from noon to midnight, lightsource was below horizon. Now lightsource below horizon from sunset till sunrise (skyAngle = 0). Also changed multiplier calculations to updated constraint: morning-noon: (0 to 1), noon-sunset (1 to 0).

## Screenshots
Before fix at noon:
<img width="548" height="465" alt="image" src="https://github.com/user-attachments/assets/0f31bbfb-c429-417b-935b-cb9b4f5479dd" />

After fix at noon:
<img width="548" height="465" alt="image" src="https://github.com/user-attachments/assets/45d61ebb-61b1-4c59-a904-8f9dbdebfc7b" />

## Suggestion
Current generation curve is linear (triangle wave). 
Could be improved to sinusoidal for more realistic solar output:
`multiplier = Math.sin(skyAngle * Math.PI / 0.5f)`