### PR TITLE
Spotless grovy lines bugfix for windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf
+
+*.bat eol=crlf
+*.cmd eol=crlf


### PR DESCRIPTION
Adds `.gitattributes` to force spotless in grovy to ignore system and use LF ending in project. 